### PR TITLE
Remove unfinished tools from the UI

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
@@ -31,27 +31,30 @@ namespace Chisel.Editors
 			public GUIContent   content;
 		}
 
+		/*
+			Jazz: Removed unfinished tools for the time being 
+		 */
 		static readonly CSGEditModeItem[] editModes = new []
 		{
 			new CSGEditModeItem(CSGEditMode.Object,			new GUIContent("Object")),
 			new CSGEditModeItem(CSGEditMode.Pivot,			new GUIContent("Pivot")),
 			new CSGEditModeItem(CSGEditMode.ShapeEdit,		new GUIContent("Shape Edit")),
-			new CSGEditModeItem(CSGEditMode.SurfaceEdit,	new GUIContent("Surface Edit")),
+			// new CSGEditModeItem(CSGEditMode.SurfaceEdit,	new GUIContent("Surface Edit")),
 			
 			new CSGEditModeItem(CSGEditMode.FreeDraw,		new GUIContent("FreeDraw")),
-			new CSGEditModeItem(CSGEditMode.RevolvedShape,	new GUIContent("Revolved Shape")),
+			// new CSGEditModeItem(CSGEditMode.RevolvedShape,	new GUIContent("Revolved Shape")),
 
 			new CSGEditModeItem(CSGEditMode.Box,			new GUIContent("Box")),
 			new CSGEditModeItem(CSGEditMode.Cylinder,		new GUIContent("Cylinder")),
-			new CSGEditModeItem(CSGEditMode.Torus,          new GUIContent("Torus")),
-			new CSGEditModeItem(CSGEditMode.Hemisphere,		new GUIContent("Hemisphere")),
-			new CSGEditModeItem(CSGEditMode.Sphere,			new GUIContent("Sphere")),
-			new CSGEditModeItem(CSGEditMode.Capsule,        new GUIContent("Capsule")),
-			new CSGEditModeItem(CSGEditMode.Stadium,        new GUIContent("Stadium")),
+			// new CSGEditModeItem(CSGEditMode.Torus,          new GUIContent("Torus")),
+			// new CSGEditModeItem(CSGEditMode.Hemisphere,		new GUIContent("Hemisphere")),
+			// new CSGEditModeItem(CSGEditMode.Sphere,			new GUIContent("Sphere")),
+			// new CSGEditModeItem(CSGEditMode.Capsule,        new GUIContent("Capsule")),
+			// new CSGEditModeItem(CSGEditMode.Stadium,        new GUIContent("Stadium")),
 
-			new CSGEditModeItem(CSGEditMode.PathedStairs,   new GUIContent("Pathed Stairs")),
-			new CSGEditModeItem(CSGEditMode.LinearStairs,	new GUIContent("Linear Stairs")),
-			new CSGEditModeItem(CSGEditMode.SpiralStairs,   new GUIContent("Spiral Stairs"))
+			// new CSGEditModeItem(CSGEditMode.PathedStairs,   new GUIContent("Pathed Stairs")),
+			// new CSGEditModeItem(CSGEditMode.LinearStairs,	new GUIContent("Linear Stairs")),
+			// new CSGEditModeItem(CSGEditMode.SpiralStairs,   new GUIContent("Spiral Stairs"))
 		};
 
 


### PR DESCRIPTION
For the time being, we should focus on improving and perfecting a small set of tools to work with. This gives us the opportunity to get familiar with the codebase and hit a quality level that we can match with each added feature.

I removed the following tools from the UI:
* `Surface Edit` - This will be big project to implement correctly, so would be good to tackle separately.
* `Revolved Shape` - Currently does nothing in Chisel
* `Torus` - As above
* `Hemisphere` - As above
* `Capsule` - As above
* `Stadium` - As above
* `Sphere` - Untested, not mandatory for a minimal set of features
* `Various Stairs` -  As above