### PR TITLE
Fixed some plane ray-casting issues

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/PointDrawing.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/PointDrawing.cs
@@ -76,14 +76,14 @@ namespace Chisel.Editors
 					var bestDist = float.PositiveInfinity;
 					float dist;
 
-					if (surfaceGridPlane.Raycast(forwardRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = forwardRay.GetPoint(dist); } }
-					if (surfaceGridPlane.Raycast(backRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = backRay   .GetPoint(dist); } }
-					if (surfaceGridPlane.Raycast(leftRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = leftRay   .GetPoint(dist); } }
-					if (surfaceGridPlane.Raycast(rightRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = rightRay  .GetPoint(dist); } }
+					if (surfaceGridPlane.UnsignedRaycast(forwardRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = forwardRay.GetPoint(dist); } }
+					if (surfaceGridPlane.UnsignedRaycast(backRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = backRay   .GetPoint(dist); } }
+					if (surfaceGridPlane.UnsignedRaycast(leftRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = leftRay   .GetPoint(dist); } }
+					if (surfaceGridPlane.UnsignedRaycast(rightRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = rightRay  .GetPoint(dist); } }
 					if (bestDist > 100000) // prefer rays on the active-grid, only go up/down from the active-grid when we have no other choice
 					{
-						if (surfaceGridPlane.Raycast(upRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = upRay     .GetPoint(dist); } }
-						if (surfaceGridPlane.Raycast(downRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = downRay   .GetPoint(dist); } }
+						if (surfaceGridPlane.UnsignedRaycast(upRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = upRay     .GetPoint(dist); } }
+						if (surfaceGridPlane.UnsignedRaycast(downRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = downRay   .GetPoint(dist); } }
 					}
 
 					// TODO: try to snap the new surface grid point in other directions on the active-grid? (do we need to?)

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/CSGClickSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/CSGClickSelectionManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
+using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
@@ -456,7 +457,7 @@ namespace Chisel.Editors
 				var gridPlane = UnitySceneExtensions.Grid.ActiveGrid.PlaneXZ;
 				var mouseRay = UnityEditor.HandleUtility.GUIPointToWorldRay(mousePosition);
 				var dist = 0.0f;
-				if (gridPlane.Raycast(mouseRay, out dist))
+				if (gridPlane.UnsignedRaycast(mouseRay, out dist))
 					return new PlaneIntersection(mouseRay.GetPoint(dist), gridPlane);
 			}
 			return null;

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
@@ -507,7 +507,7 @@ namespace UnitySceneExtensions
 			var worldRay = UnityEditor.HandleUtility.GUIPointToWorldRay(guiPosition);
 			var dist = 0.0f;
 
-			if (!worldSlidePlane.Raycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
+			if (!worldSlidePlane.UnsignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
 			worldPlanePosition = worldRay.GetPoint(dist);
 			return true;
 		}

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Utilities/Plane.Extension.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Utilities/Plane.Extension.cs
@@ -24,5 +24,19 @@ namespace UnitySceneExtensions
 									  (c * translation.z)));
 		}
 #endif
+		public static bool UnsignedRaycast(this Plane plane, Ray ray, out float enter)
+		{
+			float vdot = Vector3.Dot(ray.direction, plane.normal);
+			float ndot = -Vector3.Dot(ray.origin, plane.normal) - plane.distance;
+
+			if (Mathf.Approximately(vdot, 0.0f))
+			{
+				enter = 0.0F;
+				return false;
+			}
+
+			enter = ndot / vdot;
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
Unity's own Plane.Raycast returns false (failure) when a ray enters the plane from behind,
but in our case we want it to succeed, so I made a version of Raycast called UnsignedRaycast
and use that instead. This fixes several plane related problems.
Also in surface mode reverted to simpler UV translation code until improved version is done
Related to #22