### PR TITLE
Surface edit mode rudimentary snapping support

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.public/Assets/CSGBrushMeshAsset/CSGBrushMeshAsset.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Assets/CSGBrushMeshAsset/CSGBrushMeshAsset.cs
@@ -34,11 +34,11 @@ namespace Chisel.Assets
 			public Orientation() { }
 			public Orientation(Orientation other)
 			{
-				plane = other.plane;
+				localPlane = other.localPlane;
 				localToPlaneSpace = other.localToPlaneSpace;
 				planeToLocalSpace = other.planeToLocalSpace;
 			}
-			[HideInInspector] [SerializeField] public Plane		plane;
+			[HideInInspector] [SerializeField] public Plane		localPlane;
 			[HideInInspector] [SerializeField] public Matrix4x4 localToPlaneSpace;
 			[HideInInspector] [SerializeField] public Matrix4x4 planeToLocalSpace;
 			public Vector3 Tangent { get { return localToPlaneSpace.GetRow(0); } }
@@ -109,7 +109,7 @@ namespace Chisel.Assets
 				if (edgeCount <= 0)
 				{
 					if (orientations[i] == null) orientations[i] = new Orientation();
-					orientations[i].plane = new Plane(Vector3.up, 0);
+					orientations[i].localPlane = new Plane(Vector3.up, 0);
 					orientations[i].localToPlaneSpace = Matrix4x4.identity;
 					orientations[i].planeToLocalSpace = Matrix4x4.identity;
 					continue;
@@ -133,8 +133,8 @@ namespace Chisel.Assets
 				d /= edgeCount;
 				
 				if (orientations[i] == null) orientations[i] = new Orientation();
-				orientations[i].plane = new Plane(normal, d);
-				orientations[i].localToPlaneSpace = MathExtensions.GenerateLocalToPlaneSpaceMatrix(orientations[i].plane);
+				orientations[i].localPlane = new Plane(normal, d);
+				orientations[i].localToPlaneSpace = MathExtensions.GenerateLocalToPlaneSpaceMatrix(orientations[i].localPlane);
 				orientations[i].planeToLocalSpace = Matrix4x4.Inverse(orientations[i].localToPlaneSpace);
 			}
 		}

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/CSGNode.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/CSGNode.cs
@@ -1,4 +1,3 @@
-//#define BE_CHATTY
 using UnityEngine;
 using System.Collections;
 using System;
@@ -9,41 +8,41 @@ using Chisel.Assets;
 
 namespace Chisel.Components
 {
-	// TODO: put in separate file
-	[Serializable]
-	public sealed class SurfaceReference : IEquatable<SurfaceReference>, IEqualityComparer<SurfaceReference>
-	{
-		public CSGNode				node;
-		public CSGBrushMeshAsset	brushMeshAsset;
-		public int                  subNodeIndex;
-		public int                  subMeshIndex;
-		public int					surfaceID;
-		public int					surfaceIndex;
+    // TODO: put in separate file
+    [Serializable]
+    public sealed class SurfaceReference : IEquatable<SurfaceReference>, IEqualityComparer<SurfaceReference>
+    {
+        public CSGNode				node;
+        public CSGBrushMeshAsset	brushMeshAsset;
+        public int                  subNodeIndex;
+        public int                  subMeshIndex;
+        public int					surfaceID;
+        public int					surfaceIndex;
 
-		public SurfaceReference(CSGNode node, CSGBrushMeshAsset brushMeshAsset, int subNodeIndex, int subMeshIndex, int surfaceIndex, int surfaceID)
-		{
-			this.node = node;
-			this.brushMeshAsset = brushMeshAsset;
-			this.subNodeIndex = subNodeIndex;
-			this.subMeshIndex = subMeshIndex;
-			this.surfaceIndex = surfaceIndex;
-			this.surfaceID = surfaceID;
-		}
+        public SurfaceReference(CSGNode node, CSGBrushMeshAsset brushMeshAsset, int subNodeIndex, int subMeshIndex, int surfaceIndex, int surfaceID)
+        {
+            this.node = node;
+            this.brushMeshAsset = brushMeshAsset;
+            this.subNodeIndex = subNodeIndex;
+            this.subMeshIndex = subMeshIndex;
+            this.surfaceIndex = surfaceIndex;
+            this.surfaceID = surfaceID;
+        }
 
-		public CSGBrushSubMesh.Polygon Polygon
-		{
-			get
-			{
-				if (!brushMeshAsset)
-					return null;
-				if (subMeshIndex < 0 || subMeshIndex >= brushMeshAsset.SubMeshCount)
-					return null;
-				var subMesh = brushMeshAsset.SubMeshes[subMeshIndex];
-				if (surfaceIndex < 0 || surfaceIndex >= subMesh.Polygons.Length)
-					return null;
-				return subMesh.Polygons[surfaceIndex];
-			}
-		}
+        public CSGBrushSubMesh.Polygon Polygon
+        {
+            get
+            {
+                if (!brushMeshAsset)
+                    return null;
+                if (subMeshIndex < 0 || subMeshIndex >= brushMeshAsset.SubMeshCount)
+                    return null;
+                var subMesh = brushMeshAsset.SubMeshes[subMeshIndex];
+                if (surfaceIndex < 0 || surfaceIndex >= subMesh.Polygons.Length)
+                    return null;
+                return subMesh.Polygons[surfaceIndex];
+            }
+        }
 
         public CSGBrushSubMesh SubMesh
         {
@@ -58,40 +57,40 @@ namespace Chisel.Components
         }
 
         public IEnumerable<Vector3> PolygonVertices
-		{
-			get
-			{
-				if (!brushMeshAsset)
-					yield break;
-				if (subMeshIndex < 0 || subMeshIndex >= brushMeshAsset.SubMeshCount)
-					yield break;
-				var subMesh = brushMeshAsset.SubMeshes[subMeshIndex];
-				if (surfaceIndex < 0 || surfaceIndex >= subMesh.Polygons.Length)
-					yield break;
-				var polygon		= subMesh.Polygons[surfaceIndex];
-				var edges		= subMesh.HalfEdges;
-				var vertices	= subMesh.Vertices;
-				var firstEdge	= polygon.firstEdge;
-				var lastEdge	= firstEdge + polygon.edgeCount;
-				for (int e = firstEdge; e < lastEdge; e++)
-					yield return vertices[edges[e].vertexIndex];
-			}
-		}
+        {
+            get
+            {
+                if (!brushMeshAsset)
+                    yield break;
+                if (subMeshIndex < 0 || subMeshIndex >= brushMeshAsset.SubMeshCount)
+                    yield break;
+                var subMesh = brushMeshAsset.SubMeshes[subMeshIndex];
+                if (surfaceIndex < 0 || surfaceIndex >= subMesh.Polygons.Length)
+                    yield break;
+                var polygon		= subMesh.Polygons[surfaceIndex];
+                var edges		= subMesh.HalfEdges;
+                var vertices	= subMesh.Vertices;
+                var firstEdge	= polygon.firstEdge;
+                var lastEdge	= firstEdge + polygon.edgeCount;
+                for (int e = firstEdge; e < lastEdge; e++)
+                    yield return vertices[edges[e].vertexIndex];
+            }
+        }
 
-		public CSGBrushSubMesh.Orientation Orientation
-		{
-			get
-			{
-				if (!brushMeshAsset)
-					return null;
-				if (subMeshIndex < 0 || subMeshIndex >= brushMeshAsset.SubMeshCount)
-					return null;
-				var subMesh = brushMeshAsset.SubMeshes[subMeshIndex];
-				if (surfaceIndex < 0 || surfaceIndex >= subMesh.Orientations.Length)
-					return null;
-				return subMesh.Orientations[surfaceIndex];
-			}
-		}
+        public CSGBrushSubMesh.Orientation Orientation
+        {
+            get
+            {
+                if (!brushMeshAsset)
+                    return null;
+                if (subMeshIndex < 0 || subMeshIndex >= brushMeshAsset.SubMeshCount)
+                    return null;
+                var subMesh = brushMeshAsset.SubMeshes[subMeshIndex];
+                if (surfaceIndex < 0 || surfaceIndex >= subMesh.Orientations.Length)
+                    return null;
+                return subMesh.Orientations[surfaceIndex];
+            }
+        }
 
         public Plane? WorldPlane
         {
@@ -109,328 +108,328 @@ namespace Chisel.Components
         }
 
         public CSGTreeBrush TreeBrush
-		{
-			get
-			{
-				if (node == null)
-					return (CSGTreeBrush)CSGTreeNode.InvalidNode;
-				return (CSGTreeBrush)node.GetTreeNodeByIndex(subNodeIndex);
-			}
-		}
+        {
+            get
+            {
+                if (node == null)
+                    return (CSGTreeBrush)CSGTreeNode.InvalidNode;
+                return (CSGTreeBrush)node.GetTreeNodeByIndex(subNodeIndex);
+            }
+        }
 
-		public Matrix4x4 LocalToWorldSpace
-		{
-			get
-			{
-				if (node == null)
-					return Matrix4x4.identity;
-				
-				return node.hierarchyItem.LocalToWorldMatrix;
-			}
-		}
+        public Matrix4x4 LocalToWorldSpace
+        {
+            get
+            {
+                if (node == null)
+                    return Matrix4x4.identity;
+                
+                return node.hierarchyItem.LocalToWorldMatrix;
+            }
+        }
 
-		public Matrix4x4 WorldToLocalSpace
-		{
-			get
-			{
-				if (node == null)
-					return Matrix4x4.identity;
-				
-				return node.hierarchyItem.WorldToLocalMatrix;
-			}
-		}
+        public Matrix4x4 WorldToLocalSpace
+        {
+            get
+            {
+                if (node == null)
+                    return Matrix4x4.identity;
+                
+                return node.hierarchyItem.WorldToLocalMatrix;
+            }
+        }
 
-		public Matrix4x4 WorldToPlaneSpace
-		{
-			get
-			{
-				if (node == null)
-					return Matrix4x4.identity;
+        public Matrix4x4 WorldToPlaneSpace
+        {
+            get
+            {
+                if (node == null)
+                    return Matrix4x4.identity;
 
-				var orientation			= Orientation;
-				if (orientation == null)
-					return Matrix4x4.identity;
+                var orientation			= Orientation;
+                if (orientation == null)
+                    return Matrix4x4.identity;
 
-				var worldToLocal		= node.hierarchyItem.WorldToLocalMatrix;
-				return orientation.localToPlaneSpace * worldToLocal;
-			}	
-		}
+                var worldToLocal		= node.hierarchyItem.WorldToLocalMatrix;
+                return orientation.localToPlaneSpace * worldToLocal;
+            }	
+        }
 
-		public Matrix4x4 PlaneToWorldSpace
-		{
-			get
-			{
-				return Matrix4x4.Inverse(WorldToPlaneSpace);
-			}
-		}
+        public Matrix4x4 PlaneToWorldSpace
+        {
+            get
+            {
+                return Matrix4x4.Inverse(WorldToPlaneSpace);
+            }
+        }
 
-		public Matrix4x4 WorldSpaceToPlaneSpace(in Matrix4x4 worldSpaceTransformation)
-		{
-			var worldToPlaneSpace = WorldToPlaneSpace;
-			var planeToWorldSpace = Matrix4x4.Inverse(worldToPlaneSpace);
+        public Matrix4x4 WorldSpaceToPlaneSpace(in Matrix4x4 worldSpaceTransformation)
+        {
+            var worldToPlaneSpace = WorldToPlaneSpace;
+            var planeToWorldSpace = Matrix4x4.Inverse(worldToPlaneSpace);
 
-			return worldToPlaneSpace * worldSpaceTransformation * planeToWorldSpace;
-		}
+            return worldToPlaneSpace * worldSpaceTransformation * planeToWorldSpace;
+        }
 
-		public void WorldSpaceTransformUV(in Matrix4x4 worldSpaceTransformation, in UVMatrix originalMatrix)
-		{
-			var planeSpaceTransformation = WorldSpaceToPlaneSpace(in worldSpaceTransformation);
-			PlaneSpaceTransformUV(in planeSpaceTransformation, in originalMatrix);
-		}
+        public void WorldSpaceTransformUV(in Matrix4x4 worldSpaceTransformation, in UVMatrix originalMatrix)
+        {
+            var planeSpaceTransformation = WorldSpaceToPlaneSpace(in worldSpaceTransformation);
+            PlaneSpaceTransformUV(in planeSpaceTransformation, in originalMatrix);
+        }
 
-		public void PlaneSpaceTransformUV(in Matrix4x4 planeSpaceTransformation, in UVMatrix originalMatrix)
-		{
+        public void PlaneSpaceTransformUV(in Matrix4x4 planeSpaceTransformation, in UVMatrix originalMatrix)
+        {
             // TODO: We're modifying uv coordinates for the generated brush-meshes, 
             //       when we should be changing surfaces descriptions in the generators that generate the brush-meshes ..
             //       Now all UVs are overridden everytime we rebuild the geometry
-			Polygon.description.UV0 = (UVMatrix)((Matrix4x4)originalMatrix * planeSpaceTransformation);
-			brushMeshAsset.SetDirty();
-		}
+            Polygon.description.UV0 = (UVMatrix)((Matrix4x4)originalMatrix * planeSpaceTransformation);
+            brushMeshAsset.SetDirty();
+        }
 
 
-		#region Equals
-		public bool Equals(SurfaceReference other)
-		{
-			return Equals(this, other);
-		}
+        #region Equals
+        public bool Equals(SurfaceReference other)
+        {
+            return Equals(this, other);
+        }
 
-		public bool Equals(SurfaceReference x, SurfaceReference y)
-		{
-			if (ReferenceEquals(x, y))
-				return true;
-			if (ReferenceEquals(x, null) ||
-				ReferenceEquals(y, null))
-				return false;
-			return	//x.treeBrush			== y.treeBrush &&
-					x.brushMeshAsset	== y.brushMeshAsset &&
-					x.subNodeIndex		== y.subNodeIndex &&
-					x.subMeshIndex		== y.subMeshIndex &&
-					x.surfaceID			== y.surfaceID &&
-					x.surfaceIndex		== y.surfaceIndex;
-		}
-		
-		public override bool Equals(object obj)
-		{
-			if (ReferenceEquals(this, obj))
-				return true;
-			var other = obj as SurfaceReference;
-			if (ReferenceEquals(other, null))
-				return false;
-			return Equals(this, other);
-		}
-		#endregion
+        public bool Equals(SurfaceReference x, SurfaceReference y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (ReferenceEquals(x, null) ||
+                ReferenceEquals(y, null))
+                return false;
+            return	//x.treeBrush			== y.treeBrush &&
+                    x.brushMeshAsset	== y.brushMeshAsset &&
+                    x.subNodeIndex		== y.subNodeIndex &&
+                    x.subMeshIndex		== y.subMeshIndex &&
+                    x.surfaceID			== y.surfaceID &&
+                    x.surfaceIndex		== y.surfaceIndex;
+        }
+        
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+                return true;
+            var other = obj as SurfaceReference;
+            if (ReferenceEquals(other, null))
+                return false;
+            return Equals(this, other);
+        }
+        #endregion
 
-		#region GetHashCode
-		public override int GetHashCode()
-		{
-			return GetHashCode(this);
-		}
+        #region GetHashCode
+        public override int GetHashCode()
+        {
+            return GetHashCode(this);
+        }
 
-		public int GetHashCode(SurfaceReference obj)
-		{
-			return  //obj.treeBrush.NodeID.GetHashCode() ^
-					obj.brushMeshAsset.GetInstanceID() ^
-					obj.subNodeIndex ^
-					obj.subMeshIndex ^
-					obj.surfaceID ^
-					obj.surfaceIndex;
-		}
-		#endregion
-	}
-	
-	// TODO: put in separate file
-	[Serializable]
-	public sealed class SurfaceIntersection
-	{
-		public SurfaceReference			surface;
-		public CSGSurfaceIntersection	intersection;
-	}
+        public int GetHashCode(SurfaceReference obj)
+        {
+            return  //obj.treeBrush.NodeID.GetHashCode() ^
+                    obj.brushMeshAsset.GetInstanceID() ^
+                    obj.subNodeIndex ^
+                    obj.subMeshIndex ^
+                    obj.surfaceID ^
+                    obj.surfaceIndex;
+        }
+        #endregion
+    }
+    
+    // TODO: put in separate file
+    [Serializable]
+    public sealed class SurfaceIntersection
+    {
+        public SurfaceReference			surface;
+        public CSGSurfaceIntersection	intersection;
+    }
 
-	[DisallowMultipleComponent]
-	//[ExcludeFromObjectFactoryAttribute]
-	public abstract class CSGNode : MonoBehaviour
-	{
-		public abstract string NodeTypeName { get; }
+    [DisallowMultipleComponent]
+    //[ExcludeFromObjectFactoryAttribute]
+    public abstract class CSGNode : MonoBehaviour
+    {
+        public abstract string NodeTypeName { get; }
 
-		public CSGNode()			{ hierarchyItem = new CSGHierarchyItem(this); CSGNodeHierarchyManager.Register(this); }
-		protected void OnDestroy()	{ CSGNodeHierarchyManager.Unregister(this); OnCleanup(); }
-		public void OnValidate()	{ OnValidateInternal(); }
+        public CSGNode()			{ hierarchyItem = new CSGHierarchyItem(this); CSGNodeHierarchyManager.Register(this); }
+        protected void OnDestroy()	{ CSGNodeHierarchyManager.Unregister(this); OnCleanup(); }
+        public void OnValidate()	{ OnValidateInternal(); }
 
-		protected virtual void OnValidateInternal() { SetDirty(); }
+        protected virtual void OnValidateInternal() { SetDirty(); }
 
-		public void Reset() { OnResetInternal(); }
-		protected virtual void OnResetInternal() { OnInitialize(); }
+        public void Reset() { OnResetInternal(); }
+        protected virtual void OnResetInternal() { OnInitialize(); }
 
-		public virtual void OnInitialize() { }
-		protected virtual void OnCleanup() {  }
+        public virtual void OnInitialize() { }
+        protected virtual void OnCleanup() {  }
 
-		[NonSerialized][HideInInspector] public readonly CSGHierarchyItem hierarchyItem;
+        [NonSerialized][HideInInspector] public readonly CSGHierarchyItem hierarchyItem;
 
-		protected void OnEnable()
-		{
+        protected void OnEnable()
+        {
 #if BE_CHATTY
-			Debug.Log("OnEnable " + this.name, this);
+            Debug.Log("OnEnable " + this.name, this);
 #endif
-			OnInitialize(); // Awake is not reliable, so we initialize here
-			CSGNodeHierarchyManager.UpdateAvailability(this);
-		}
+            OnInitialize(); // Awake is not reliable, so we initialize here
+            CSGNodeHierarchyManager.UpdateAvailability(this);
+        }
 
 
-		public abstract Bounds CalculateBounds();/*
-		{
-			CSGBrushMeshAsset[] assets = GetUsedBrushMeshAssets();
-			if (assets == null || assets.Length == 0)
-				return CSGHierarchyItem.EmptyBounds;
+        public abstract Bounds CalculateBounds();/*
+        {
+            CSGBrushMeshAsset[] assets = GetUsedBrushMeshAssets();
+            if (assets == null || assets.Length == 0)
+                return CSGHierarchyItem.EmptyBounds;
 
-			if (assets.Length == 1)
-			{
-				if (!assets[0])
-					return CSGHierarchyItem.EmptyBounds;
-			}
-			
-			var modelTransform		= CSGNodeHierarchyManager.FindModelTransformOfTransform(hierarchyItem.Transform);
-			var localToWorldMatrix	= hierarchyItem.Transform.localToWorldMatrix;
-			var bounds = CSGHierarchyItem.EmptyBounds;
-			var haveBounds = false;
-			foreach (var asset in assets)
-			{
-				if (!asset)
-					continue;
-				var assetBounds = asset.CalculateBounds(localToWorldMatrix);
-				if (assetBounds.size.sqrMagnitude == 0)
-					continue;
-				if (!haveBounds)
-				{
-					bounds = assetBounds;
-					haveBounds = true;
-				} else
-					bounds.Encapsulate(assetBounds);
-			}
-			return bounds;
-		}*/
+            if (assets.Length == 1)
+            {
+                if (!assets[0])
+                    return CSGHierarchyItem.EmptyBounds;
+            }
+            
+            var modelTransform		= CSGNodeHierarchyManager.FindModelTransformOfTransform(hierarchyItem.Transform);
+            var localToWorldMatrix	= hierarchyItem.Transform.localToWorldMatrix;
+            var bounds = CSGHierarchyItem.EmptyBounds;
+            var haveBounds = false;
+            foreach (var asset in assets)
+            {
+                if (!asset)
+                    continue;
+                var assetBounds = asset.CalculateBounds(localToWorldMatrix);
+                if (assetBounds.size.sqrMagnitude == 0)
+                    continue;
+                if (!haveBounds)
+                {
+                    bounds = assetBounds;
+                    haveBounds = true;
+                } else
+                    bounds.Encapsulate(assetBounds);
+            }
+            return bounds;
+        }*/
 
-		public bool EncapsulateBounds(ref Bounds outBounds)
-		{
-			hierarchyItem.EncapsulateBounds(ref outBounds);
-			return true;
-		}
+        public bool EncapsulateBounds(ref Bounds outBounds)
+        {
+            hierarchyItem.EncapsulateBounds(ref outBounds);
+            return true;
+        }
 
-		protected void OnDisable()
-		{
+        protected void OnDisable()
+        {
 #if BE_CHATTY
-			Debug.Log("OnDisable " + this.name, this);
+            Debug.Log("OnDisable " + this.name, this);
 #endif
-			// Note: cannot call OnCleanup here
-			CSGNodeHierarchyManager.UpdateAvailability(this);
-		}
-		
-		// Called when the parent property of the transform has changed.
-		protected void OnTransformParentChanged()
-		{
+            // Note: cannot call OnCleanup here
+            CSGNodeHierarchyManager.UpdateAvailability(this);
+        }
+        
+        // Called when the parent property of the transform has changed.
+        protected void OnTransformParentChanged()
+        {
 #if BE_CHATTY
-			Debug.Log("OnTransformParentChanged " + this.name, this);
+            Debug.Log("OnTransformParentChanged " + this.name, this);
 #endif
-			CSGNodeHierarchyManager.OnTransformParentChanged(this);
-		}
-	
-		// Called when the list of children of the transform has changed.
-		protected void OnTransformChildrenChanged()
-		{
+            CSGNodeHierarchyManager.OnTransformParentChanged(this);
+        }
+    
+        // Called when the list of children of the transform has changed.
+        protected void OnTransformChildrenChanged()
+        {
 #if BE_CHATTY
-			Debug.Log("OnTransformChildrenChanged " + this.name, this);
+            Debug.Log("OnTransformChildrenChanged " + this.name, this);
 #endif
-			CSGNodeHierarchyManager.OnTransformChildrenChanged(this);
-		}
-	
-		public bool				Dirty					{ get { return CSGNodeHierarchyManager.IsNodeDirty(this); } }
-		public virtual int		NodeID					{ get { return CSGTreeNode.InvalidNode.NodeID; } }
-		internal virtual bool	SkipThisNode			{ get { return !isActiveAndEnabled; } }
+            CSGNodeHierarchyManager.OnTransformChildrenChanged(this);
+        }
+    
+        public bool				Dirty					{ get { return CSGNodeHierarchyManager.IsNodeDirty(this); } }
+        public virtual int		NodeID					{ get { return CSGTreeNode.InvalidNode.NodeID; } }
+        internal virtual bool	SkipThisNode			{ get { return !isActiveAndEnabled; } }
 
-		// Can this Node contain child CSGNodes?
-		public virtual bool		CanHaveChildNodes		{ get { return false; } }
+        // Can this Node contain child CSGNodes?
+        public virtual bool		CanHaveChildNodes		{ get { return false; } }
 
-		// Does this node have a container treeNode that can hold child treeNodes?
-		public virtual bool		HasContainerTreeNode	{ get { return CanHaveChildNodes; } }
-		public virtual bool		CreatesTreeNode			{ get { return true; } }
-		
-		public virtual CSGTreeNode	GetTreeNodeByIndex(int index)
-		{
-			return CSGTreeNode.InvalidNode;
-		}
+        // Does this node have a container treeNode that can hold child treeNodes?
+        public virtual bool		HasContainerTreeNode	{ get { return CanHaveChildNodes; } }
+        public virtual bool		CreatesTreeNode			{ get { return true; } }
+        
+        public virtual CSGTreeNode	GetTreeNodeByIndex(int index)
+        {
+            return CSGTreeNode.InvalidNode;
+        }
 
-		public abstract void SetDirty();
+        public abstract void SetDirty();
 
-		internal abstract CSGTreeNode[] CreateTreeNodes();
-		internal abstract void			ClearTreeNodes(bool clearCaches = false);
-		internal virtual void			UpdateTransformation() { }
-		public virtual void				UpdateBrushMeshInstances() { }
+        internal abstract CSGTreeNode[] CreateTreeNodes();
+        internal abstract void			ClearTreeNodes(bool clearCaches = false);
+        internal virtual void			UpdateTransformation() { }
+        public virtual void				UpdateBrushMeshInstances() { }
 
-		internal virtual void SetChildren(List<CSGTreeNode> childNodes) { }
+        internal virtual void SetChildren(List<CSGTreeNode> childNodes) { }
 
-		internal virtual void CollectChildNodesForParent(List<CSGTreeNode> childNodes) { }
+        internal virtual void CollectChildNodesForParent(List<CSGTreeNode> childNodes) { }
 
-		public virtual CSGBrushMeshAsset[] GetUsedBrushMeshAssets() { return null; }
-		
-		public abstract int GetAllTreeBrushCount();
+        public virtual CSGBrushMeshAsset[] GetUsedBrushMeshAssets() { return null; }
+        
+        public abstract int GetAllTreeBrushCount();
 
-		// Get all brushes directly contained by this CSGNode
-		public abstract void GetAllTreeBrushes(HashSet<CSGTreeBrush> foundBrushes, bool ignoreSynchronizedBrushes);
+        // Get all brushes directly contained by this CSGNode
+        public abstract void GetAllTreeBrushes(HashSet<CSGTreeBrush> foundBrushes, bool ignoreSynchronizedBrushes);
 
-		public virtual CSGSurfaceAsset FindSurfaceAsset(CSGTreeBrush brush, int surfaceID)
-		{
-			return null;
-		}
+        public virtual CSGSurfaceAsset FindSurfaceAsset(CSGTreeBrush brush, int surfaceID)
+        {
+            return null;
+        }
 
-		public virtual CSGSurfaceAsset[] GetAllSurfaceAssets(CSGTreeBrush brush)
-		{
-			return null;
-		}
-		
-		public virtual SurfaceReference FindSurfaceReference(CSGTreeBrush brush, int surfaceID)
-		{
-			return null;
-		}
+        public virtual CSGSurfaceAsset[] GetAllSurfaceAssets(CSGTreeBrush brush)
+        {
+            return null;
+        }
+        
+        public virtual SurfaceReference FindSurfaceReference(CSGTreeBrush brush, int surfaceID)
+        {
+            return null;
+        }
 
-		public virtual SurfaceReference[] GetAllSurfaceReferences(CSGTreeBrush brush)
-		{
-			return null;
-		}
-		
-		public virtual SurfaceReference[] GetAllSurfaceReferences()
-		{
-			return null;
-		}
+        public virtual SurfaceReference[] GetAllSurfaceReferences(CSGTreeBrush brush)
+        {
+            return null;
+        }
+        
+        public virtual SurfaceReference[] GetAllSurfaceReferences()
+        {
+            return null;
+        }
 
 
-		public virtual Vector3 SetPivot(Vector3 newWorldPosition)
-		{
-			var transform		= hierarchyItem.Transform;
-			var currentPosition = transform.position;
-			if (currentPosition == newWorldPosition)
-				return Vector3.zero;
-			transform.position = newWorldPosition;
-			var delta = newWorldPosition - currentPosition;
-			AddPivotOffset(-delta);
-			return delta;
-		}
+        public virtual Vector3 SetPivot(Vector3 newWorldPosition)
+        {
+            var transform		= hierarchyItem.Transform;
+            var currentPosition = transform.position;
+            if (currentPosition == newWorldPosition)
+                return Vector3.zero;
+            transform.position = newWorldPosition;
+            var delta = newWorldPosition - currentPosition;
+            AddPivotOffset(-delta);
+            return delta;
+        }
 
-		internal virtual void AddPivotOffset(Vector3 worldSpaceDelta)
-		{
-			for (int c = 0; c < hierarchyItem.Children.Count; c++)
-			{
-				var child = hierarchyItem.Children[c];
-				child.Component.AddPivotOffset(worldSpaceDelta);
-			}
-		}
+        internal virtual void AddPivotOffset(Vector3 worldSpaceDelta)
+        {
+            for (int c = 0; c < hierarchyItem.Children.Count; c++)
+            {
+                var child = hierarchyItem.Children[c];
+                child.Component.AddPivotOffset(worldSpaceDelta);
+            }
+        }
 
 #if UNITY_EDITOR
-			// The icon used in the hierarchy
-		public abstract GUIContent Icon { get; }
+            // The icon used in the hierarchy
+        public abstract GUIContent Icon { get; }
 
-		public virtual bool ConvertToBrushes()
-		{
-			return false;
-		}
+        public virtual bool ConvertToBrushes()
+        {
+            return false;
+        }
 #endif
-	}
+    }
 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/CSGNode.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/CSGNode.cs
@@ -267,9 +267,6 @@ namespace Chisel.Components
 
         protected void OnEnable()
         {
-#if BE_CHATTY
-            Debug.Log("OnEnable " + this.name, this);
-#endif
             OnInitialize(); // Awake is not reliable, so we initialize here
             CSGNodeHierarchyManager.UpdateAvailability(this);
         }
@@ -316,9 +313,6 @@ namespace Chisel.Components
 
         protected void OnDisable()
         {
-#if BE_CHATTY
-            Debug.Log("OnDisable " + this.name, this);
-#endif
             // Note: cannot call OnCleanup here
             CSGNodeHierarchyManager.UpdateAvailability(this);
         }
@@ -326,18 +320,12 @@ namespace Chisel.Components
         // Called when the parent property of the transform has changed.
         protected void OnTransformParentChanged()
         {
-#if BE_CHATTY
-            Debug.Log("OnTransformParentChanged " + this.name, this);
-#endif
             CSGNodeHierarchyManager.OnTransformParentChanged(this);
         }
     
         // Called when the list of children of the transform has changed.
         protected void OnTransformChildrenChanged()
         {
-#if BE_CHATTY
-            Debug.Log("OnTransformChildrenChanged " + this.name, this);
-#endif
             CSGNodeHierarchyManager.OnTransformChildrenChanged(this);
         }
     

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/EditModes/CSGSurfaceEditMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/EditModes/CSGSurfaceEditMode.cs
@@ -20,46 +20,46 @@ namespace Chisel.Editors
         static readonly int kSurfaceScaleHash			= "SurfaceScale".GetHashCode();
         static readonly int kSurfaceRotateHash			= "SurfaceRotate".GetHashCode();
         static readonly int kSurfaceMoveHash			= "SurfaceMove".GetHashCode();
-		
+        
         static bool InEditCameraMode	{ get { return (Tools.viewTool == ViewTool.Pan || Tools.viewTool == ViewTool.None); } }
         static bool ToolIsDragging		{ get; set; }
         static bool MouseIsDown			{ get; set; }
-		
+        
 
-		// TODO: shouldn't 'just' always show the default tools
-		public void OnEnable() { Tools.hidden = true; }
-		public void OnDisable() { }
-		
+        // TODO: shouldn't 'just' always show the default tools
+        public void OnEnable() { Tools.hidden = true; }
+        public void OnDisable() { }
+        
 
         public void OnSceneGUI(SceneView sceneView, Rect dragArea)
-		{
-			var defaultID = GUIUtility.GetControlID(kSurfaceEditModeHash, FocusType.Passive, dragArea);
+        {
+            var defaultID = GUIUtility.GetControlID(kSurfaceEditModeHash, FocusType.Passive, dragArea);
             HandleUtility.AddDefaultControl(defaultID);
 
             var selectionType	= CSGRectSelectionManager.GetCurrentSelectionType();
             var repaint			= SurfaceSelection(dragArea, selectionType);
-			var cursor			= MouseCursor.Arrow;
+            var cursor			= MouseCursor.Arrow;
 
-			// Handle tool specific actions
-			switch (Tools.current)
+            // Handle tool specific actions
+            switch (Tools.current)
             {
                 case Tool.Move:		repaint = SurfaceMoveTool(selectionType,   dragArea) || repaint; cursor = MouseCursor.MoveArrow;   break;
                 case Tool.Rotate:	repaint = SurfaceRotateTool(selectionType, dragArea) || repaint; cursor = MouseCursor.RotateArrow; break;
                 case Tool.Scale:	repaint = SurfaceScaleTool(selectionType,  dragArea) || repaint; cursor = MouseCursor.ScaleArrow;  break;
                 //case Tool.Rect:	break;
             }
-			
-			// Set cursor depending on selection type and/or active tool
-			{ 
-				switch (selectionType)
-				{
-					case SelectionType.Additive:    cursor = MouseCursor.ArrowPlus; break;
-					case SelectionType.Subtractive: cursor = MouseCursor.ArrowMinus; break;
-				}
-				EditorGUIUtility.AddCursorRect(dragArea, cursor);
-			}
             
-			// Repaint the scene-views if we need to
+            // Set cursor depending on selection type and/or active tool
+            { 
+                switch (selectionType)
+                {
+                    case SelectionType.Additive:    cursor = MouseCursor.ArrowPlus; break;
+                    case SelectionType.Subtractive: cursor = MouseCursor.ArrowMinus; break;
+                }
+                EditorGUIUtility.AddCursorRect(dragArea, cursor);
+            }
+            
+            // Repaint the scene-views if we need to
             if (repaint &&
                 // avoid infinite loop
                 Event.current.type != EventType.Layout &&
@@ -99,65 +99,65 @@ namespace Chisel.Editors
                 return;
 
             var grid				= UnitySceneExtensions.Grid.defaultGrid;
-			var gridSnappedPoint	= Snapping.SnapPoint(intersectionPoint, grid);
+            var gridSnappedPoint	= Snapping.SnapPoint(intersectionPoint, grid);
 
-			var worldPlane  = surfaceReference.WorldPlane.Value;
+            var worldPlane  = surfaceReference.WorldPlane.Value;
 
-			var xAxis       = grid.Right;
-			var yAxis       = grid.Up;
-			var zAxis       = grid.Forward;
+            var xAxis       = grid.Right;
+            var yAxis       = grid.Up;
+            var zAxis       = grid.Forward;
             var snapAxis    = Axis.X | Axis.Y | Axis.Z;
             if (Mathf.Abs(Vector3.Dot(xAxis, worldPlane.normal)) >= kAlignmentEpsilon) snapAxis &= ~Axis.X;
             if (Mathf.Abs(Vector3.Dot(yAxis, worldPlane.normal)) >= kAlignmentEpsilon) snapAxis &= ~Axis.Y;
             if (Mathf.Abs(Vector3.Dot(zAxis, worldPlane.normal)) >= kAlignmentEpsilon) snapAxis &= ~Axis.Z;
 
             if (Mathf.Abs(worldPlane.GetDistanceToPoint(gridSnappedPoint)) < kDistanceEpsilon)
-			{
-				bestDist = (gridSnappedPoint - intersectionPoint).magnitude * preferenceFactor;
-				snappedPoint = gridSnappedPoint;
-			} else
-			{
-				float dist;
-				var ray = new Ray(gridSnappedPoint, xAxis);
-				if ((snapAxis & Axis.X) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
-				{
-					var planePoint = ray.GetPoint(dist);
-					var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
-					if (abs_dist < bestDist)
-					{
-						bestDist = abs_dist;
-						snappedPoint = planePoint;
-					}
-				}
-				ray.direction = yAxis;
-				if ((snapAxis & Axis.Y) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
-				{
-					var planePoint = ray.GetPoint(dist);
-					var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
-					if (abs_dist < bestDist)
-					{
-						bestDist = abs_dist;
-						snappedPoint = planePoint;
-					}
-				}
-				ray.direction = zAxis;
-				if ((snapAxis & Axis.Z) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
-				{
-					var planePoint = ray.GetPoint(dist);
-					var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
-					if (abs_dist < bestDist)
-					{
-						bestDist = abs_dist;
-						snappedPoint = planePoint;
-					}
-				}
-			}
-		}
+            {
+                bestDist = (gridSnappedPoint - intersectionPoint).magnitude * preferenceFactor;
+                snappedPoint = gridSnappedPoint;
+            } else
+            {
+                float dist;
+                var ray = new Ray(gridSnappedPoint, xAxis);
+                if ((snapAxis & Axis.X) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                {
+                    var planePoint = ray.GetPoint(dist);
+                    var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
+                    if (abs_dist < bestDist)
+                    {
+                        bestDist = abs_dist;
+                        snappedPoint = planePoint;
+                    }
+                }
+                ray.direction = yAxis;
+                if ((snapAxis & Axis.Y) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                {
+                    var planePoint = ray.GetPoint(dist);
+                    var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
+                    if (abs_dist < bestDist)
+                    {
+                        bestDist = abs_dist;
+                        snappedPoint = planePoint;
+                    }
+                }
+                ray.direction = zAxis;
+                if ((snapAxis & Axis.Z) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                {
+                    var planePoint = ray.GetPoint(dist);
+                    var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
+                    if (abs_dist < bestDist)
+                    {
+                        bestDist = abs_dist;
+                        snappedPoint = planePoint;
+                    }
+                }
+            }
+        }
 
-		static void SnapSurfaceVertices(UVSnapSettings snapSettings, SurfaceReference surfaceReference, Vector3 intersectionPoint, float preferenceFactor, ref Vector3 snappedPoint, ref float bestDist)
-		{
-			if (surfaceReference == null)
-				return;
+        static void SnapSurfaceVertices(UVSnapSettings snapSettings, SurfaceReference surfaceReference, Vector3 intersectionPoint, float preferenceFactor, ref Vector3 snappedPoint, ref float bestDist)
+        {
+            if (surfaceReference == null)
+                return;
 
             if ((snapSettings & UVSnapSettings.GeometryVertices) == UVSnapSettings.None)
                 return;
@@ -172,31 +172,31 @@ namespace Chisel.Editors
             var firstEdge           = polygon.firstEdge;
             var lastEdge            = firstEdge + polygon.edgeCount;
             
-			var bestDistSqr			= float.PositiveInfinity;
-			var bestVertex			= snappedPoint;
+            var bestDistSqr			= float.PositiveInfinity;
+            var bestVertex			= snappedPoint;
             for (int e = firstEdge; e < lastEdge; e++)
             {
-				var worldSpaceVertex = localToWorldSpace.MultiplyPoint(vertices[edges[e].vertexIndex]);
-				var dist_sqr         = (worldSpaceVertex - intersectionPoint).sqrMagnitude;
-				if (dist_sqr < bestDistSqr)
-				{
-					bestDistSqr = dist_sqr;
-					bestVertex = worldSpaceVertex;
-				}
+                var worldSpaceVertex = localToWorldSpace.MultiplyPoint(vertices[edges[e].vertexIndex]);
+                var dist_sqr         = (worldSpaceVertex - intersectionPoint).sqrMagnitude;
+                if (dist_sqr < bestDistSqr)
+                {
+                    bestDistSqr = dist_sqr;
+                    bestVertex = worldSpaceVertex;
+                }
             }
 
-			if (float.IsInfinity(bestDistSqr))
-				return;
+            if (float.IsInfinity(bestDistSqr))
+                return;
 
             var closestVertexDistance = Mathf.Sqrt(bestDistSqr) * preferenceFactor;
             if (closestVertexDistance < bestDist)
-			{
-				bestDist = closestVertexDistance;
-				snappedPoint = bestVertex;
-			}
-		}
+            {
+                bestDist = closestVertexDistance;
+                snappedPoint = bestVertex;
+            }
+        }
 
-		static void SnapSurfaceEdges(UVSnapSettings snapSettings, SurfaceReference surfaceReference, Vector3 intersectionPoint, float preferenceFactor, ref Vector3 snappedPoint, ref float bestDist)
+        static void SnapSurfaceEdges(UVSnapSettings snapSettings, SurfaceReference surfaceReference, Vector3 intersectionPoint, float preferenceFactor, ref Vector3 snappedPoint, ref float bestDist)
         {
             if (surfaceReference == null)
                 return;
@@ -209,9 +209,9 @@ namespace Chisel.Editors
             Debug.Assert(surfaceReference.surfaceIndex >= 0 && surfaceReference.surfaceIndex < subMesh.Polygons.Length);
 
             var grid        = UnitySceneExtensions.Grid.defaultGrid;
-			var xAxis       = grid.Right;
-			var yAxis       = grid.Up;
-			var zAxis       = grid.Forward;
+            var xAxis       = grid.Right;
+            var yAxis       = grid.Up;
+            var zAxis       = grid.Forward;
             var intersectionPlane  = surfaceReference.WorldPlane.Value;
 
             var snapAxis    = Axis.X | Axis.Y | Axis.Z;
@@ -267,49 +267,49 @@ namespace Chisel.Editors
                     if (edgeSnapAxis == Axis.None)
                         continue;
 
-				    float dist;
-				    var ray = new Ray(snappedPoint, xAxis);
-				    if ((edgeSnapAxis & Axis.X) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
-				    {
-					    var planePoint = ray.GetPoint(dist);
-					    var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
-					    if (abs_dist < bestDist)
-					    {
-						    bestDist = abs_dist;
-						    snappedPoint = planePoint;
-					    }
-				    }
-				    ray.direction = yAxis;
-				    if ((edgeSnapAxis & Axis.Y) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
-				    {
-					    var planePoint = ray.GetPoint(dist);
-					    var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
-					    if (abs_dist < bestDist)
-					    {
-						    bestDist = abs_dist;
-						    snappedPoint = planePoint;
-					    }
-				    }
-				    ray.direction = zAxis;
-				    if ((edgeSnapAxis & Axis.Z) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
-				    {
-					    var planePoint = ray.GetPoint(dist);
-					    var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
-					    if (abs_dist < bestDist)
-					    {
-						    bestDist = abs_dist;
-						    snappedPoint = planePoint;
-					    }
-				    }
+                    float dist;
+                    var ray = new Ray(snappedPoint, xAxis);
+                    if ((edgeSnapAxis & Axis.X) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                    {
+                        var planePoint = ray.GetPoint(dist);
+                        var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
+                        if (abs_dist < bestDist)
+                        {
+                            bestDist = abs_dist;
+                            snappedPoint = planePoint;
+                        }
+                    }
+                    ray.direction = yAxis;
+                    if ((edgeSnapAxis & Axis.Y) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                    {
+                        var planePoint = ray.GetPoint(dist);
+                        var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
+                        if (abs_dist < bestDist)
+                        {
+                            bestDist = abs_dist;
+                            snappedPoint = planePoint;
+                        }
+                    }
+                    ray.direction = zAxis;
+                    if ((edgeSnapAxis & Axis.Z) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                    {
+                        var planePoint = ray.GetPoint(dist);
+                        var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
+                        if (abs_dist < bestDist)
+                        {
+                            bestDist = abs_dist;
+                            snappedPoint = planePoint;
+                        }
+                    }
                 } else
                 { 
                     var closestPoint    = worldPlane.ClosestPointOnPlane(intersectionPoint);
-				    var dist            = (closestPoint - intersectionPoint).magnitude * preferenceFactor;
-				    if (dist < bestDist)
-				    {
-					    bestDist = dist;
+                    var dist            = (closestPoint - intersectionPoint).magnitude * preferenceFactor;
+                    if (dist < bestDist)
+                    {
+                        bestDist = dist;
                         snappedPoint = closestPoint;
-				    }
+                    }
                 }
             }
         }
@@ -325,7 +325,7 @@ namespace Chisel.Editors
             // TODO: visualize what we're snapping against
 
             var bestDist			= float.PositiveInfinity;
-			var snappedPoint		= intersectionPoint;
+            var snappedPoint		= intersectionPoint;
             var handleSize          = HandleUtility.GetHandleSize(intersectionPoint);
             // When holding V we force to ONLY and ALWAYS snap against vertices
             var snapSettings        = forceVertexSnapping ? UVSnapSettings.GeometryVertices : CurrentSnapSettings;
@@ -364,19 +364,19 @@ namespace Chisel.Editors
 
         #endregion
 
-		#region Hover Surfaces
-		static CSGTreeBrushIntersection? hoverIntersection;
+        #region Hover Surfaces
+        static CSGTreeBrushIntersection? hoverIntersection;
         static SurfaceReference hoverSurfaceReference;
 
-		static readonly HashSet<SurfaceReference> hoverSurfaces = new HashSet<SurfaceReference>();
+        static readonly HashSet<SurfaceReference> hoverSurfaces = new HashSet<SurfaceReference>();
 
         static void RenderIntersectionPoint(Vector3 position)
         {
             if (!hoverIntersection.HasValue)
                 return;
             var intersectionPoint   = hoverIntersection.Value.surfaceIntersection.worldIntersection;
-			var normal              = hoverIntersection.Value.surfaceIntersection.worldPlane.normal;
-			SceneHandles.RenderBorderedCircle(position, HandleUtility.GetHandleSize(position) * 0.02f);
+            var normal              = hoverIntersection.Value.surfaceIntersection.worldPlane.normal;
+            SceneHandles.RenderBorderedCircle(position, HandleUtility.GetHandleSize(position) * 0.02f);
         }
 
         static void RenderVertexBox(Vector3 position)
@@ -388,31 +388,31 @@ namespace Chisel.Editors
             Handles.RectangleHandleCap(-1, position, Camera.current.transform.rotation, HandleUtility.GetHandleSize(position) * 0.1f, EventType.Repaint);
         }
 
-		static void RenderIntersection()
-		{
+        static void RenderIntersection()
+        {
             if (Event.current.type != EventType.Repaint)
                 return;
 
-			if (ToolIsDragging)
-				return;
+            if (ToolIsDragging)
+                return;
 
-			if (!hoverIntersection.HasValue)
-				return;
+            if (!hoverIntersection.HasValue)
+                return;
 
             var position = hoverIntersection.Value.surfaceIntersection.worldIntersection;
             RenderIntersectionPoint(position);
             if (forceVertexSnapping)
                 RenderVertexBox(position);
-		}
+        }
 
-		static bool UpdateHoverSurfaces(Vector2 mousePosition, Rect dragArea, SelectionType selectionType, bool clearHovering)
+        static bool UpdateHoverSurfaces(Vector2 mousePosition, Rect dragArea, SelectionType selectionType, bool clearHovering)
         {
             try
             {
-				hoverIntersection = null;
+                hoverIntersection = null;
                 hoverSurfaceReference = null;
 
-				bool modified = false;
+                bool modified = false;
                 if (clearHovering || !InEditCameraMode)
                 {
                     if (hoverSurfaces.Count != 0)
@@ -428,15 +428,15 @@ namespace Chisel.Editors
                 if (!InEditCameraMode)
                     return modified;
 
-				CSGTreeBrushIntersection intersection;
-				SurfaceReference surfaceReference;
-				var foundSurfaces = CSGClickSelectionManager.FindSurfaceReference(mousePosition, false, out intersection, out surfaceReference);
-				if (foundSurfaces == null)
+                CSGTreeBrushIntersection intersection;
+                SurfaceReference surfaceReference;
+                var foundSurfaces = CSGClickSelectionManager.FindSurfaceReference(mousePosition, false, out intersection, out surfaceReference);
+                if (foundSurfaces == null)
                 {
                     modified = (hoverSurfaces != null) || modified;
-					hoverIntersection = null;
-					return modified;
-				}
+                    hoverIntersection = null;
+                    return modified;
+                }
 
                 if (!float.IsInfinity(intersection.surfaceIntersection.distance))
                 {
@@ -449,8 +449,8 @@ namespace Chisel.Editors
                 else
                     modified = true;
 
-				if (foundSurfaces.Length > 0)
-					hoverSurfaces.AddRange(foundSurfaces);
+                if (foundSurfaces.Length > 0)
+                    hoverSurfaces.AddRange(foundSurfaces);
                 return modified;
             }
             finally
@@ -459,9 +459,9 @@ namespace Chisel.Editors
             }
         }
         #endregion
-		
-		#region Selection
-		static bool ClickSelection(Rect dragArea, SelectionType selectionType)
+        
+        #region Selection
+        static bool ClickSelection(Rect dragArea, SelectionType selectionType)
         {
             return CSGSurfaceSelectionManager.UpdateSelection(selectionType, hoverSurfaces);
         }
@@ -552,56 +552,56 @@ namespace Chisel.Editors
             return repaint;
         }
 
-		static void ResetSelection()
-		{
-			hoverIntersection = null;
-            hoverSurfaceReference = null;
-			selectedSurfaceReferences = null;
-			selectedBrushMeshAsset = null;
-			selectedUVMatrices = null;
-		}
-		#endregion
-
-		#region Tool Base
-		static bool CanEnableTool(int id)
+        static void ResetSelection()
         {
-			// Is another control enabled at the moment?
-			if (GUIUtility.hotControl != 0)
-				return false;
-			            
+            hoverIntersection = null;
+            hoverSurfaceReference = null;
+            selectedSurfaceReferences = null;
+            selectedBrushMeshAsset = null;
+            selectedUVMatrices = null;
+        }
+        #endregion
+
+        #region Tool Base
+        static bool CanEnableTool(int id)
+        {
+            // Is another control enabled at the moment?
+            if (GUIUtility.hotControl != 0)
+                return false;
+                        
             var evt = Event.current;
-			// Is our tool currently the control nearest to the mouse?
-			if ((UnityEditor.HandleUtility.nearestControl != id || evt.button != 0) &&
-				(GUIUtility.keyboardControl != id || evt.button != 2))
-				return false;
+            // Is our tool currently the control nearest to the mouse?
+            if ((UnityEditor.HandleUtility.nearestControl != id || evt.button != 0) &&
+                (GUIUtility.keyboardControl != id || evt.button != 2))
+                return false;
             return true;
         }
 
         static bool IsToolEnabled(int id)
-		{
-			// Is our control enabled at the moment?
-			return GUIUtility.hotControl == id;
+        {
+            // Is our control enabled at the moment?
+            return GUIUtility.hotControl == id;
         }
 
 
         static void EnableTool(int id)
         {
             EditorGUIUtility.SetWantsMouseJumping(1);   // enable allowing the user to move the mouse over the bounds of the screen
-			jumpedMousePosition = Event.current.mousePosition;  // remember the current mouse position so we can update it using Event.current.delta, 
-																// since mousePosition won't make sense any more when mouse jumping
-			GUIUtility.hotControl = GUIUtility.keyboardControl = id; // set our tool as the active control
+            jumpedMousePosition = Event.current.mousePosition;  // remember the current mouse position so we can update it using Event.current.delta, 
+                                                                // since mousePosition won't make sense any more when mouse jumping
+            GUIUtility.hotControl = GUIUtility.keyboardControl = id; // set our tool as the active control
             Event.current.Use(); // make sure no-one else can use our event
 
 
             toolSnapOverrides = (UVSnapSettings)~0;
             pointHasSnapped = false;
-		}
+        }
 
         static void DisableTool()
         {
             EditorGUIUtility.SetWantsMouseJumping(0); // disable allowing the user to move the mouse over the bounds of the screen
             GUIUtility.hotControl = GUIUtility.keyboardControl = 0; // remove the active control so that the user can use another control
-			Event.current.Use(); // make sure no-one else can use our event
+            Event.current.Use(); // make sure no-one else can use our event
 
 
             toolSnapOverrides = (UVSnapSettings)~0;
@@ -614,7 +614,7 @@ namespace Chisel.Editors
             Undo.RevertAllInCurrentGroup();
             Event.current.Use();
             GUIUtility.ExitGUI(); // avoids a nullreference exception in sceneview
-		}
+        }
 
         const float kMaxControlDistance = 3.0f;
         private static bool SurfaceToolBase(int id, SelectionType selectionType, Rect dragArea)
@@ -699,31 +699,31 @@ namespace Chisel.Editors
                     // In case we somehow missed a MouseUp event, we reset this bool
                     MouseIsDown = false;
                     break;
-				}
-				case EventType.MouseDown:
+                }
+                case EventType.MouseDown:
                 {
-					// we can only use a tool when the mouse cursor is inside the draggable scene area
-					if (!dragArea.Contains(evt.mousePosition))
-						return false;
+                    // we can only use a tool when the mouse cursor is inside the draggable scene area
+                    if (!dragArea.Contains(evt.mousePosition))
+                        return false;
 
-					// we can only use a tool when we're hovering over a surfaces
-					if (hoverSurfaces == null || hoverSurfaces.Count == 0)
-						return false;
+                    // we can only use a tool when we're hovering over a surfaces
+                    if (hoverSurfaces == null || hoverSurfaces.Count == 0)
+                        return false;
 
-					if (!CanEnableTool(id))
-						break;
+                    if (!CanEnableTool(id))
+                        break;
 
-					// We want to be able to tell the difference between dragging and clicking,
-					// so we don't initialize dragging until we actually do
-					MouseIsDown = true;
+                    // We want to be able to tell the difference between dragging and clicking,
+                    // so we don't initialize dragging until we actually do
+                    MouseIsDown = true;
                     ToolIsDragging = false;
 
-					EnableTool(id); 
+                    EnableTool(id); 
                     break;
                 }
                 case EventType.MouseDrag:
                 {
-					if (!IsToolEnabled(id))
+                    if (!IsToolEnabled(id))
                         break;
                     
                     if (!ToolIsDragging)
@@ -741,25 +741,25 @@ namespace Chisel.Editors
                         break;
                     
                     MouseIsDown = false;
-					// We clicked, but didn't actually drag, so we can do a click selection
+                    // We clicked, but didn't actually drag, so we can do a click selection
                     if (!ToolIsDragging)
                     {
                         // if we clicked on the surface, instead of dragged it, just click select it
                         ClickSelection(dragArea, selectionType);
                     }
 
-					ToolIsDragging = false;
+                    ToolIsDragging = false;
 
-					DisableTool();
-					ResetSelection();
-					break;
-				}
-				case EventType.Repaint:
-				{
-					RenderIntersection();
-					break;
-				}
-			}
+                    DisableTool();
+                    ResetSelection();
+                    break;
+                }
+                case EventType.Repaint:
+                {
+                    RenderIntersection();
+                    break;
+                }
+            }
             return true;
         }
 
@@ -770,59 +770,59 @@ namespace Chisel.Editors
         static Plane                worldDragPlane;
         static Plane                worldProjectionPlane;
         static Vector3				worldStartPosition;
-		static Vector3				worldIntersection;
+        static Vector3				worldIntersection;
         static Vector3              worldDragDeltaVector;
         static Vector2              jumpedMousePosition;
 
         private static bool StartToolDragging()
-		{
-			jumpedMousePosition += Event.current.delta;
-			Event.current.Use();
-			if (ToolIsDragging)
+        {
+            jumpedMousePosition += Event.current.delta;
+            Event.current.Use();
+            if (ToolIsDragging)
             {
                 UpdateDragVector();
-				return false;
+                return false;
             }
 
-			ToolIsDragging = true;
+            ToolIsDragging = true;
 
-			// Find the intersecting surfaces
-			startSurfaceReference           = hoverSurfaceReference;
+            // Find the intersecting surfaces
+            startSurfaceReference           = hoverSurfaceReference;
             var currentIntersection         = hoverIntersection.Value.surfaceIntersection;
 
             selectedSurfaceReferences	= CSGSurfaceSelectionManager.Selection.ToArray();
 
-			// We need all the brushMeshAssets for all the surfaces we're moving, so that we can record them for an undo
+            // We need all the brushMeshAssets for all the surfaces we're moving, so that we can record them for an undo
             selectedBrushMeshAsset		= CSGSurfaceSelectionManager.SelectedBrushMeshes.ToArray();
 
-			// We copy all the original surface uvMatrices, so we always apply rotations and transformations relatively to the original
-			// This makes it easier to recover from edge cases and makes it more accurate, floating point wise.
+            // We copy all the original surface uvMatrices, so we always apply rotations and transformations relatively to the original
+            // This makes it easier to recover from edge cases and makes it more accurate, floating point wise.
             selectedUVMatrices			= new UVMatrix[selectedSurfaceReferences.Length];
             for (int i = 0; i < selectedSurfaceReferences.Length; i++)
                 selectedUVMatrices[i] = selectedSurfaceReferences[i].Polygon.description.UV0;
             
-			// Find the intersection point/plane in model space
+            // Find the intersection point/plane in model space
             var nodeTransform		= startSurfaceReference.node.hierarchyItem.Transform;
             var modelTransform		= CSGNodeHierarchyManager.FindModelTransformOfTransform(nodeTransform);
             worldStartPosition		= modelTransform.localToWorldMatrix.MultiplyPoint (hoverIntersection.Value.surfaceIntersection.worldIntersection);
             worldProjectionPlane	= modelTransform.localToWorldMatrix.TransformPlane(hoverIntersection.Value.surfaceIntersection.worldPlane);
-			worldIntersection = worldStartPosition;
+            worldIntersection = worldStartPosition;
 
-			// TODO: we want to be able to determine delta movement over a plane. Ideally it would match the position of the cursor perfectly.
-			//		 unfortunately when moving the cursor towards the horizon of the plane, relative to the camera, the delta movement 
-			//		 becomes too large or even infinity. Ideally we'd switch to a camera facing plane for these cases and determine movement in 
-			//		 a less perfect way that would still allow the user to move or rotate things in a reasonable way.
+            // TODO: we want to be able to determine delta movement over a plane. Ideally it would match the position of the cursor perfectly.
+            //		 unfortunately when moving the cursor towards the horizon of the plane, relative to the camera, the delta movement 
+            //		 becomes too large or even infinity. Ideally we'd switch to a camera facing plane for these cases and determine movement in 
+            //		 a less perfect way that would still allow the user to move or rotate things in a reasonable way.
 
-			// more accurate for small movements
-			worldDragPlane		= worldProjectionPlane;
+            // more accurate for small movements
+            worldDragPlane		= worldProjectionPlane;
 
-			// TODO: (unfinished) prevents drag-plane from intersecting near plane (makes movement slow down to a singularity when further away from click position)
-			//worldDragPlane	= new Plane(Camera.current.transform.forward, worldStartPosition); 
+            // TODO: (unfinished) prevents drag-plane from intersecting near plane (makes movement slow down to a singularity when further away from click position)
+            //worldDragPlane	= new Plane(Camera.current.transform.forward, worldStartPosition); 
 
-			// TODO: ideally we'd interpolate the behavior of the worldPlane between near and far behavior
+            // TODO: ideally we'd interpolate the behavior of the worldPlane between near and far behavior
             UpdateDragVector();
-			return true;
-		}
+            return true;
+        }
 
         private static Vector3 GetCurrentWorldClick(Vector2 mousePosition)
         {
@@ -854,24 +854,24 @@ namespace Chisel.Editors
             worldDragDeltaVector = deltaVector;
         }
         #endregion
-		
+        
         #region Surface Scale Tool
-		private static bool SurfaceScaleTool(SelectionType selectionType, Rect dragArea)
+        private static bool SurfaceScaleTool(SelectionType selectionType, Rect dragArea)
         {
             var id = GUIUtility.GetControlID(kSurfaceScaleHash, FocusType.Keyboard, dragArea);
             if (!SurfaceToolBase(id, selectionType, dragArea))
                 return false;
 
-			bool needRepaint = false;            
+            bool needRepaint = false;            
             switch (Event.current.GetTypeForControl(id))
-			{
-				// TODO: support scaling texture using keyboard
-				case EventType.Repaint:
-				{
-					// TODO: show scaling of uv
-					break;
-				}
-				case EventType.MouseDrag:
+            {
+                // TODO: support scaling texture using keyboard
+                case EventType.Repaint:
+                {
+                    // TODO: show scaling of uv
+                    break;
+                }
+                case EventType.MouseDrag:
                 {
                     if (!IsToolEnabled(id))
                         break;
@@ -879,7 +879,7 @@ namespace Chisel.Editors
                     StartToolDragging();
 
                     var dragVector = worldDragDeltaVector;
-					break;
+                    break;
                 }
             }
             return needRepaint;
@@ -908,9 +908,9 @@ namespace Chisel.Editors
             }
         }
 
-		static Vector3 fromWorldVector;
-		static bool		haveRotateStartAngle	= false;
-		static float	rotateAngle	            = 0;
+        static Vector3 fromWorldVector;
+        static bool		haveRotateStartAngle	= false;
+        static float	rotateAngle	            = 0;
 
         const float		kMinRotateDiameter		= 1.0f;
         private static bool SurfaceRotateTool(SelectionType selectionType, Rect dragArea)
@@ -921,19 +921,19 @@ namespace Chisel.Editors
             
             bool needRepaint = false;            
             if (!IsToolEnabled(id))
-			{
-				needRepaint = haveRotateStartAngle;
+            {
+                needRepaint = haveRotateStartAngle;
                 haveRotateStartAngle = false;
                 pointHasSnapped = false;
             }
-			
+            
             switch (Event.current.GetTypeForControl(id))
-			{
-				// TODO: support rotating texture using keyboard?
-				case EventType.Repaint:
-				{
-					if (haveRotateStartAngle)
-					{
+            {
+                // TODO: support rotating texture using keyboard?
+                case EventType.Repaint:
+                {
+                    if (haveRotateStartAngle)
+                    {
                         var toWorldVector   = worldDragDeltaVector;
                         var magnitude       = toWorldVector.magnitude;
                         toWorldVector /= magnitude;
@@ -956,17 +956,17 @@ namespace Chisel.Editors
                             RenderIntersectionPoint(worldIntersection);
                             RenderVertexBox(worldIntersection);
                         }
-					} 
-					break;
-				}
-				case EventType.MouseDrag:
-				{
-					if (!IsToolEnabled(id))
+                    } 
+                    break;
+                }
+                case EventType.MouseDrag:
+                {
+                    if (!IsToolEnabled(id))
                         break;
                     
                     if (StartToolDragging())
                     {
-					    haveRotateStartAngle = false;
+                        haveRotateStartAngle = false;
                         pointHasSnapped = false;
                     }
 
@@ -975,12 +975,12 @@ namespace Chisel.Editors
                     {
                         var handleSize		= HandleUtility.GetHandleSize(worldStartPosition);	
                         var minDiameterSqr	= handleSize * kMinRotateDiameter;
-						// Only start rotating when we've moved the cursor far away enough from the center of rotation
-						if (toWorldVector.sqrMagnitude > minDiameterSqr)
-						{
-							// Switch to rotation mode, we have a center and a start angle to compare with, 
-							// from now on, when we move the mouse we change the rotation angle relative to this first angle.
-							haveRotateStartAngle = true;
+                        // Only start rotating when we've moved the cursor far away enough from the center of rotation
+                        if (toWorldVector.sqrMagnitude > minDiameterSqr)
+                        {
+                            // Switch to rotation mode, we have a center and a start angle to compare with, 
+                            // from now on, when we move the mouse we change the rotation angle relative to this first angle.
+                            haveRotateStartAngle = true;
                             pointHasSnapped = false;
                             fromWorldVector = toWorldVector.normalized;
                             rotateAngle = 0;
@@ -993,7 +993,7 @@ namespace Chisel.Editors
                         }
                     } else
                     {
-						// Get the angle between 'from' and 'to' on the plane we're dragging over
+                        // Get the angle between 'from' and 'to' on the plane we're dragging over
                         rotateAngle = MathExtensions.SignedAngle(fromWorldVector, toWorldVector.normalized, worldDragPlane.normal);
                         
                         // If we snapped against something, ignore angle snapping
@@ -1023,17 +1023,17 @@ namespace Chisel.Editors
         }
 
         private static bool SurfaceMoveTool(SelectionType selectionType, Rect dragArea)
-		{
-			var id = GUIUtility.GetControlID(kSurfaceMoveHash, FocusType.Keyboard, dragArea);
+        {
+            var id = GUIUtility.GetControlID(kSurfaceMoveHash, FocusType.Keyboard, dragArea);
             if (!SurfaceToolBase(id, selectionType, dragArea))
                 return false;
 
-			bool needRepaint = false;
-			switch (Event.current.GetTypeForControl(id))
-			{
-				// TODO: support moving texture using keyboard
-				case EventType.Repaint:
-				{
+            bool needRepaint = false;
+            switch (Event.current.GetTypeForControl(id))
+            {
+                // TODO: support moving texture using keyboard
+                case EventType.Repaint:
+                {
                     if (!ToolIsDragging)
                         break;
 
@@ -1042,11 +1042,11 @@ namespace Chisel.Editors
                     break;
                 }
                 case EventType.MouseDrag:
-				{
-					if (!IsToolEnabled(id))
+                {
+                    if (!IsToolEnabled(id))
                         break;
 
-					StartToolDragging();
+                    StartToolDragging();
                     TranslateSurfacesInWorldSpace(-worldDragDeltaVector); // TODO: figure out why this is reversed
                     break;
                 }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/EditModes/CSGSurfaceEditMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/EditModes/CSGSurfaceEditMode.cs
@@ -702,11 +702,11 @@ namespace Chisel.Editors
                 }
                 case EventType.MouseDown:
                 {
-                    // we can only use a tool when the mouse cursor is inside the draggable scene area
+                    // We can only use a tool when the mouse cursor is inside the draggable scene area
                     if (!dragArea.Contains(evt.mousePosition))
                         return false;
 
-                    // we can only use a tool when we're hovering over a surfaces
+                    // We can only use a tool when we're hovering over a surfaces
                     if (hoverSurfaces == null || hoverSurfaces.Count == 0)
                         return false;
 
@@ -714,9 +714,9 @@ namespace Chisel.Editors
                         break;
 
                     // We want to be able to tell the difference between dragging and clicking,
-                    // so we don't initialize dragging until we actually do
-                    MouseIsDown = true;
+                    // so we keep track if we dragged or not. In this case we haven't started dragging yet.
                     ToolIsDragging = false;
+                    MouseIsDown = true;
 
                     EnableTool(id); 
                     break;
@@ -725,14 +725,18 @@ namespace Chisel.Editors
                 {
                     if (!IsToolEnabled(id))
                         break;
-                    
+
                     if (!ToolIsDragging)
                     {
-                        // if we haven't dragged the tool yet, check if the surface underneath 
+                        // If we haven't dragged the tool yet, check if the surface underneath 
                         // the mouse is selected or not, if it isn't: select it exclusively
                         if (!CSGSurfaceSelectionManager.IsAnySelected(hoverSurfaces))
                             ClickSelection(dragArea, selectionType);
                     }
+
+                    // In the tool specific code, calling StartToolDragging will set ToolIsDragging to true, 
+                    // which will allow us to tell the difference between clicking and dragging.
+
                     break;
                 }
                 case EventType.MouseUp:
@@ -741,10 +745,12 @@ namespace Chisel.Editors
                         break;
                     
                     MouseIsDown = false;
-                    // We clicked, but didn't actually drag, so we can do a click selection
+
+                    // We want to be able to tell the difference between clicking and dragging, 
+                    // so we use ToolIsDragging here to determine if we clicked.
                     if (!ToolIsDragging)
                     {
-                        // if we clicked on the surface, instead of dragged it, just click select it
+                        // If we clicked on the surface, instead of dragged it, just click select it
                         ClickSelection(dragArea, selectionType);
                     }
 
@@ -784,6 +790,7 @@ namespace Chisel.Editors
                 return false;
             }
 
+            // We set ToolIsDragging to true to be able to tell the difference between dragging and clicking
             ToolIsDragging = true;
 
             // Find the intersecting surfaces

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
@@ -39,7 +39,7 @@ namespace Chisel.Editors
 			new CSGEditModeItem(CSGEditMode.Object,			new GUIContent("Object")),
 			new CSGEditModeItem(CSGEditMode.Pivot,			new GUIContent("Pivot")),
 			new CSGEditModeItem(CSGEditMode.ShapeEdit,		new GUIContent("Shape Edit")),
-			// new CSGEditModeItem(CSGEditMode.SurfaceEdit,	new GUIContent("Surface Edit")),
+			new CSGEditModeItem(CSGEditMode.SurfaceEdit,	new GUIContent("Surface Edit")),
 			
 			new CSGEditModeItem(CSGEditMode.FreeDraw,		new GUIContent("FreeDraw")),
 			// new CSGEditModeItem(CSGEditMode.RevolvedShape,	new GUIContent("Revolved Shape")),

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/CSGClickSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/CSGClickSelectionManager.cs
@@ -1,4 +1,4 @@
-﻿using Chisel.Assets;
+using Chisel.Assets;
 using Chisel.Core;
 using Chisel.Components;
 using System;
@@ -540,9 +540,10 @@ namespace Chisel.Editors
 			}
 		}
 		
-		public static SurfaceReference[] FindSurfaceReference(Vector2 position, bool selectAllSurfaces, out CSGTreeBrushIntersection intersection)
+		public static SurfaceReference[] FindSurfaceReference(Vector2 position, bool selectAllSurfaces, out CSGTreeBrushIntersection intersection, out SurfaceReference surfaceReference)
 		{
 			intersection = CSGTreeBrushIntersection.None;
+			surfaceReference = null;
 			try
 			{
 				if (!PickFirstGameObject(position, out intersection))
@@ -554,13 +555,13 @@ namespace Chisel.Editors
 				if (!node)
 					return null;
 
+				surfaceReference = node.FindSurfaceReference(brush, intersection.surfaceID);
 				if (selectAllSurfaces)
 					return node.GetAllSurfaceReferences(brush);
 
-				var surface = node.FindSurfaceReference(brush, intersection.surfaceID);
-				if (surface == null)
+				if (surfaceReference == null)
 					return null;
-				return new SurfaceReference[] { surface };
+				return new SurfaceReference[] { surfaceReference };
 			}
 			catch (Exception ex)
 			{

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Visualization/CSGOutlineRenderer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Visualization/CSGOutlineRenderer.cs
@@ -327,8 +327,8 @@ namespace Chisel.Editors
 				{
 					var surface = outline.surface;
 					if (!allSurfaces.Contains(surface) ||
-						!surface.treeBrush.Valid ||
-						surface.treeBrush.BrushMesh == BrushMeshInstance.InvalidInstance)
+						!surface.TreeBrush.Valid ||
+						surface.TreeBrush.BrushMesh == BrushMeshInstance.InvalidInstance)
 					{
 						removedSurfaces.Add(outline);
 					} else
@@ -351,11 +351,11 @@ namespace Chisel.Editors
 				
 				foreach (var outline in foundSurfaceOutlines)
 				{
-					if (!outline.surface.treeBrush.Valid ||
-						outline.surface.treeBrush.BrushMesh == BrushMeshInstance.InvalidInstance)
+					if (!outline.surface.TreeBrush.Valid ||
+						outline.surface.TreeBrush.BrushMesh == BrushMeshInstance.InvalidInstance)
 						continue;
 					
-					var wireframe = CSGWireframe.CreateWireframe(outline.surface.treeBrush, outline.surface.surfaceID);
+					var wireframe = CSGWireframe.CreateWireframe(outline.surface.TreeBrush, outline.surface.surfaceID);
 					surfaceOutlines[outline] = wireframe;
 				}
 			}
@@ -424,7 +424,7 @@ namespace Chisel.Editors
 				var wireframe	= pair.Value;
 				var outline		= pair.Key;
 				var surface		= outline.surface;
-				var treeBrush	= surface.treeBrush;
+				var treeBrush	= surface.TreeBrush;
 				if (wireframe == null)
 				{
 					if (treeBrush.Valid &&
@@ -555,7 +555,7 @@ namespace Chisel.Editors
 					if (hovered.Contains(surface))
 						continue;
 
-					var brush			= surface.treeBrush;
+					var brush			= surface.TreeBrush;
 					if (!brush.Valid)
 						continue;
 						
@@ -581,7 +581,7 @@ namespace Chisel.Editors
 					if (!hovered.Contains(surface))
 						continue;
 
-					var brush			= surface.treeBrush;
+					var brush			= surface.TreeBrush;
 					if (!brush.Valid)
 						continue;
 						


### PR DESCRIPTION
This PR adds some snapping support to surface editing
The user sees a snapped point while hovering over the surface which is the point at which the movement starts or the rotation rotates around. When holding the mouse button, the movement will snap to the closest point on the grid/closest vertex or the rotation will rotate towards a snapped position.
