### PR TITLE
No longer possible to have selection during generator mode

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/CSGUnityEventsManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/CSGUnityEventsManager.cs
@@ -176,7 +176,8 @@ namespace Chisel.Editors
         private static void OnSelectionChanged()
         {
             CSGClickSelectionManager.Instance.OnSelectionChanged();
-            CSGOutlineRenderer.Instance.OnSelectionChanged(); 
+            CSGOutlineRenderer.Instance.OnSelectionChanged();
+            CSGEditModeGUI.Instance.OnSelectionChanged();
             //Editors.CSGManagedHierarchyView.RepaintAll();
             //Editors.CSGNativeHierarchyView.RepaintAll();
         }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
@@ -108,8 +108,9 @@ namespace Chisel.Editors
                 if (EditorGUI.EndChangeCheck() && value)
                 {
                     // When we select a generator, we don't want anything else selected since the combination makes no sense.
-                    // We store the selection, however.
-                    Instance.RememberSelection();
+                    // We store the selection, however, if our previous edit mode was not a generator.
+                    if (CSGEditModeManager.EditMode < CSGEditMode.FirstGenerator)
+                        Instance.RememberSelection();
                     CSGEditModeManager.EditMode = editMode.value;
                     CSGEditorSettings.Save();
                 }
@@ -240,7 +241,7 @@ namespace Chisel.Editors
 
             if (currentToolMode != prevToolMode)
             {
-                if (prevToolMode    != null) prevToolMode.OnDisable();
+                if (prevToolMode != null) prevToolMode.OnDisable();
                 
                 // Set defaults
                 CSGOutlineRenderer.VisualizationMode = VisualizationMode.Outline;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeGUI.cs
@@ -120,6 +120,11 @@ namespace Chisel.Editors
 
         public void OnSelectionChanged()
         {
+            // Make sure we're currently in a non-generator, otherwise this makes no sense
+            // We might actually be currently restoring a selection
+            if (CSGEditModeManager.EditMode < CSGEditMode.FirstGenerator)
+                return;
+
             var activeObject = Selection.activeObject;
             // This event is fired when we select or deselect something.
             // We only care if we select something
@@ -129,7 +134,7 @@ namespace Chisel.Editors
             // We just selected something in the editor, so we want to get rid of our 
             // stored selection to avoid restoring an old selection for no reason later on.
             ClearStoredSelection();
-
+            
             var is_generator = activeObject is Components.CSGGeneratorComponent;
             if (!is_generator)
             {
@@ -147,7 +152,7 @@ namespace Chisel.Editors
 
         [SerializeField] UnityEngine.Object[] prevSelection = null;
         [SerializeField] CSGEditMode prevEditMode = CSGEditMode.Object;
-
+        
         internal bool HaveSelection()
         {
             return (prevSelection != null);
@@ -160,9 +165,15 @@ namespace Chisel.Editors
             Selection.activeObject = null;
         }
 
-        void RestoreSelection(bool skipEditMode = true)
+        void RestoreSelection(bool skipEditMode = false)
         {
-            Selection.objects = prevSelection;
+            if (prevSelection != null)
+                Selection.objects = prevSelection;
+            else
+                // Selection.objects doesn't like being set to null, 
+                // it'll generate an error, Selection.activeObject has 
+                // no problem with it however.
+                Selection.activeObject = null;
             if (!skipEditMode)
                 CSGEditModeManager.EditMode = prevEditMode;
             ClearStoredSelection();

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/CSGEditModeManager.cs
@@ -11,12 +11,15 @@ namespace Chisel.Editors
     [Serializable]
     public enum CSGEditMode
     {
+        // Edit modes
         Object,
         Pivot,
         ShapeEdit,
         SurfaceEdit,
 
-        FreeDraw,
+        // Generators
+        FirstGenerator,
+        FreeDraw = FirstGenerator,
         RevolvedShape,
         Box,
         Cylinder,


### PR DESCRIPTION
- When selecting a generator, now all selected gameobjects are remembered and deselected.
- When you now select an edit mode that is not a generator, the selection will return.
- If you select a gameobject while in a generator mode, the edit mode will become an Object or Shape Edit mode (depends on what you select). The remembered selection will be cleared.
- If you press escape while in a generator mode (but not actually generating something right now) then you go back to the previous non-generator edit mode & previous selection.