### PR TITLE
Support for "active model"

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
@@ -247,7 +247,7 @@ namespace Chisel.Components
                 var generatedMesh = model.generatedMeshes[i];
                 if (generatedMesh.renderComponents != null &&
                     generatedMesh.renderComponents.meshRenderer &&
-                    generatedMesh.renderComponents.meshFilter)
+                    generatedMesh.renderComponents.meshFilter) 
                 {
                     var material = generatedMesh.renderComponents.meshRenderer.sharedMaterial;
                     List<ChiselRenderComponents> components;
@@ -505,13 +505,7 @@ namespace Chisel.Components
             
             try
             {
-                var gameObject = new GameObject(GeneratedDefaultModelName);
-                var transform = gameObject.GetComponent<Transform>();
-                transform.localPosition = Vector3.zero;
-                transform.localRotation = Quaternion.identity;
-                transform.localScale	= Vector3.one;
-                
-                var model = gameObject.AddComponent<ChiselModel>();
+                var model = ChiselComponentFactory.Create<ChiselModel>(GeneratedDefaultModelName);
                 UpdateModelFlags(model);
                 return model;
             }
@@ -554,16 +548,24 @@ namespace Chisel.Components
             try
             {
                 CSGNodeHierarchyManager.ignoreNextChildrenChanged = true;
-                var gameObject = new GameObject(GeneratedContainerName);
-                var transform  = gameObject.GetComponent<Transform>();
-                CSGNodeHierarchyManager.ignoreNextChildrenChanged = true;
-                transform.SetParent(model.transform, false);
-                CSGNodeHierarchyManager.ignoreNextChildrenChanged = false;
-                transform.localPosition = Vector3.zero;
-                transform.localRotation = Quaternion.identity;
-                transform.localScale = Vector3.one;
-                model.GeneratedDataContainer = gameObject;
-                model.GeneratedDataTransform = transform;
+                var newGameObject = new GameObject(GeneratedContainerName);
+                newGameObject.SetActive(false);
+                try
+                {
+                    var transform  = newGameObject.GetComponent<Transform>();
+                    CSGNodeHierarchyManager.ignoreNextChildrenChanged = true;
+                    transform.SetParent(model.transform, false);
+                    CSGNodeHierarchyManager.ignoreNextChildrenChanged = false;
+                    transform.localPosition = Vector3.zero;
+                    transform.localRotation = Quaternion.identity;
+                    transform.localScale    = Vector3.one;
+                    model.GeneratedDataContainer = newGameObject;
+                    model.GeneratedDataTransform = transform;
+                }
+                finally
+                {
+                    newGameObject.SetActive(true);
+                }
                 model.OnInitialize();
             }
             finally

--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselComponentFactory.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselComponentFactory.cs
@@ -18,6 +18,9 @@ namespace Chisel.Components
     {
         public static T Create<T>(string name, UnityEngine.Transform parent, Vector3 position, Quaternion rotation, Vector3 scale) where T : ChiselNode
         {
+            // TODO: ensure we're creating this in the active scene
+            // TODO: handle scene being locked by version control
+
             if (string.IsNullOrEmpty(name))
             {
 #if UNITY_EDITOR
@@ -36,18 +39,19 @@ namespace Chisel.Components
             {
                 var brushTransform = newGameObject.transform;
 #if UNITY_EDITOR
+                if (parent)
+                    UnityEditor.Undo.SetTransformParent(brushTransform, parent, "Move child node underneath parent operation");
                 UnityEditor.Undo.RecordObject(brushTransform, "Move child node to given position");
-#endif
                 brushTransform.localPosition = position;
                 brushTransform.localRotation = rotation;
                 brushTransform.localScale = scale;
-#if UNITY_EDITOR
-                if (parent)
-                    UnityEditor.Undo.SetTransformParent(brushTransform, parent, "Move child node underneath parent operation");
                 return UnityEditor.Undo.AddComponent<T>(newGameObject);
 #else
                 if (parent)
                     brushTransform.SetParent(parent, false);
+                brushTransform.localPosition = position;
+                brushTransform.localRotation = rotation;
+                brushTransform.localScale = scale;
                 return newGameObject.AddComponent<T>();
 #endif
             }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselComponentFactory.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselComponentFactory.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 namespace Chisel.Components
 {
     // TODO: rename
-    public sealed partial class ChiselModelManager
+    public sealed class ChiselComponentFactory
     {
         public static T Create<T>(string name, UnityEngine.Transform parent, Vector3 position, Quaternion rotation, Vector3 scale) where T : ChiselNode
         {

--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Chisel.Core;
 using UnityEngine;
 
@@ -38,7 +38,7 @@ namespace Chisel.Components
 
         [SerializeField]
         public ChiselModel activeModel;
-
+        
         public static ChiselModel ActiveModel
         { 
             get
@@ -48,7 +48,7 @@ namespace Chisel.Components
                 {
                     // TODO: handle not having an active model (try and find one in the scene?)
                     return null;
-            }
+                }
                 if (!activeModel)
                 {
                     // TODO: handle active model being invalid
@@ -83,5 +83,35 @@ namespace Chisel.Components
             }
             return activeModel;
         }
+
+#if UNITY_EDITOR
+        static ChiselModel GetSelectedModel()
+        {
+            var selectedGameObjects = UnityEditor.Selection.gameObjects;
+            if (selectedGameObjects == null ||
+                selectedGameObjects.Length != 1)
+                return null;
+
+            var selection   = selectedGameObjects[0];
+            return selection.GetComponent<ChiselModel>();
+        }
+
+        const string SetActiveModelMenuName = "GameObject/Set Active Model";
+        [UnityEditor.MenuItem(SetActiveModelMenuName, false, -100000)]
+        static void SetActiveModel()
+        {
+            var model = GetSelectedModel();
+            if (!model)
+                return;
+            ChiselModelManager.ActiveModel = model;
+        }
+
+        [UnityEditor.MenuItem(SetActiveModelMenuName, true, -100000)]
+        static bool ValidateSetActiveModel()
+        {
+            var model = GetSelectedModel();
+            return (model != null);
+        }
+#endif
     }
 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
@@ -11,6 +11,7 @@ using Plane = UnityEngine.Plane;
 using Debug = UnityEngine.Debug;
 using UnitySceneExtensions;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Chisel.Components
 {
@@ -19,13 +20,38 @@ namespace Chisel.Components
     // TODO: make it possible to generate brushes in specific scenes/specific parents
     // TODO: clean up
     // TODO: rename
-    public sealed partial class ChiselModelManager
+    public class ChiselModelManager : ScriptableObject
     {
+        #region Instance
+        static ChiselModelManager _instance;
+        public static ChiselModelManager Instance
+        {
+            get
+            {
+                if (_instance)
+                    return _instance;
+
+                _instance = ScriptableObject.CreateInstance<ChiselModelManager>();
+                _instance.hideFlags = HideFlags.HideAndDontSave;
+                return _instance;
+            }
+        }
+        #endregion
+
+        [SerializeField]
+        ChiselModel activeModel;
+
         // TODO: make this part of Undo stack ...
         public static ChiselModel ActiveModel
-        {
-            get;
-            set;
+        { 
+            get
+            {
+                return Instance.activeModel;
+            }
+            set
+            { 
+                Instance.activeModel = value;
+            }
         }
 
         // TODO: improve naming
@@ -40,8 +66,8 @@ namespace Chisel.Components
             var activeModel = ChiselModelManager.ActiveModel;
             if (!activeModel)
             {
-                activeModel = ChiselModelManager.Create<ChiselModel>("Model");
-                ChiselModelManager.ActiveModel = activeModel;
+                activeModel = ChiselComponentFactory.Create<ChiselModel>("Model");
+                ChiselModelManager.ActiveModel = activeModel; 
             }
             return activeModel;
         }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
@@ -30,16 +30,30 @@ namespace Chisel.Components
             {
                 if (_instance)
                     return _instance;
-
-                _instance = ScriptableObject.CreateInstance<ChiselModelManager>();
-                _instance.hideFlags = HideFlags.HideAndDontSave;
+                
+                var foundInstances = UnityEngine.Object.FindObjectsOfType<ChiselModelManager>();
+                if (foundInstances == null ||
+                    foundInstances.Length == 0)
+                {
+                    _instance = ScriptableObject.CreateInstance<ChiselModelManager>();
+                    _instance.hideFlags = HideFlags.DontSaveInBuild;
+                    return _instance;
+                }
+                
+                if (foundInstances.Length > 1)
+                {
+                    for (int i = 1; i < foundInstances.Length; i++)
+                        UnityEngine.Object.DestroyImmediate(foundInstances[i]);
+                }
+                
+                _instance = foundInstances[0];
                 return _instance;
             }
         }
         #endregion
 
         [SerializeField]
-        ChiselModel activeModel;
+        public ChiselModel activeModel;
 
         // TODO: make this part of Undo stack ...
         public static ChiselModel ActiveModel
@@ -49,7 +63,7 @@ namespace Chisel.Components
                 return Instance.activeModel;
             }
             set
-            { 
+            {
                 Instance.activeModel = value;
             }
         }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
@@ -1,25 +1,9 @@
-﻿using System;
-using System.Linq;
+using System;
 using Chisel.Core;
-using Vector2 = UnityEngine.Vector2;
-using Vector3 = UnityEngine.Vector3;
-using Vector4 = UnityEngine.Vector4;
-using Quaternion = UnityEngine.Quaternion;
-using Matrix4x4 = UnityEngine.Matrix4x4;
-using Mathf = UnityEngine.Mathf;
-using Plane = UnityEngine.Plane;
-using Debug = UnityEngine.Debug;
-using UnitySceneExtensions;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Chisel.Components
 {
-    // TODO: have concept of active model
-    // TODO: reduce allocations, reuse existing arrays when possible
-    // TODO: make it possible to generate brushes in specific scenes/specific parents
-    // TODO: clean up
-    // TODO: rename
     public class ChiselModelManager : ScriptableObject
     {
         #region Instance
@@ -55,12 +39,23 @@ namespace Chisel.Components
         [SerializeField]
         public ChiselModel activeModel;
 
-        // TODO: make this part of Undo stack ...
         public static ChiselModel ActiveModel
         { 
             get
             {
-                return Instance.activeModel;
+                var activeModel = Instance.activeModel;
+                if (ReferenceEquals(activeModel, null))
+                {
+                    // TODO: handle not having an active model (try and find one in the scene?)
+                    return null;
+            }
+                if (!activeModel)
+                {
+                    // TODO: handle active model being invalid
+                    return null;
+                }
+                // TODO: handle active model not being in active scene
+                return activeModel;
             }
             set
             {
@@ -68,8 +63,9 @@ namespace Chisel.Components
             }
         }
 
-        // TODO: improve naming
-        public static ChiselModel GetModelForNode(ChiselModel overrideModel = null)
+        // TODO: fix this so we keep the active scene in mind, as in, when the active scene changes, 
+        // we should be using a model in the active scene, not in another scene.
+        public static ChiselModel GetActiveModelOrCreate(ChiselModel overrideModel = null)
         {
             if (overrideModel)
             {
@@ -80,6 +76,8 @@ namespace Chisel.Components
             var activeModel = ChiselModelManager.ActiveModel;
             if (!activeModel)
             {
+                // TODO: ensure we create this in the active scene
+                // TODO: handle scene being locked by version control
                 activeModel = ChiselComponentFactory.Create<ChiselModel>("Model");
                 ChiselModelManager.ActiveModel = activeModel; 
             }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/ChiselGeneratorComponent.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/ChiselGeneratorComponent.cs
@@ -762,28 +762,13 @@ namespace Chisel.Components
                     {
                         var newBrushContainerAsset = UnityEngine.ScriptableObject.CreateInstance<ChiselBrushContainerAsset>();
                         newBrushContainerAsset.SetSubMeshes(new[] { new BrushMesh(brushContainerAsset.BrushMeshes[i]) });
-                        var brushGameObject = new GameObject("Brush (" + (i + 1) + ")");
-                        UnityEditor.Undo.RegisterCreatedObjectUndo(brushGameObject, "Created GameObject");
-                        brushGameObject.SetActive(false);
-                        try
-                        {
-                            var brushTransform = brushGameObject.transform;
-                            UnityEditor.Undo.SetTransformParent(brushTransform, parentTransform, "Move child brush underneath parent operation");
-                            UnityEditor.Undo.RecordObject(brushTransform, "Reset child brush transform");
-                            brushTransform.localPosition = Vector3.zero;
-                            brushTransform.localRotation = Quaternion.identity;
-                            brushTransform.localScale = Vector3.one;
-
-                            var brush = UnityEditor.Undo.AddComponent<ChiselBrush>(brushGameObject);
-                            brush.BrushContainerAsset = newBrushContainerAsset;
-                            brush.LocalTransformation = localTransformation;
-                            brush.PivotOffset = pivotOffset;
-                            brush.Operation = brushContainerAsset.Operations[i];
-                        }
-                        finally
-                        {
-                            brushGameObject.SetActive(true);
-                        }
+                        
+                        var brush = ChiselComponentFactory.Create<ChiselBrush>("Brush (" + (i + 1) + ")", parentTransform, Vector3.zero, Quaternion.identity, Vector3.one);
+                        brush.BrushContainerAsset   = newBrushContainerAsset;
+                        brush.LocalTransformation   = localTransformation;
+                        brush.PivotOffset           = pivotOffset;
+                        brush.Operation             = brushContainerAsset.Operations[i];
+                        UnityEditor.Undo.RecordObject(brush, "Modified brush");
                     }
                     UnityEditor.Undo.SetCurrentGroupName("Converted " + NodeTypeName + " to Multiple Brushes");
                 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselModel.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselModel.cs
@@ -108,7 +108,10 @@ namespace Chisel.Components
     {
         public const string kNodeTypeName = "Model";
         public override string NodeTypeName { get { return kNodeTypeName; } }
-
+        
+        [ContextMenu("Set Active Model")]
+        void SetActiveModel() { ChiselModelManager.ActiveModel = this; }
+        
 
         [HideInInspector, SerializeField] CSGGeneratedColliderSettings  colliderSettings    = new CSGGeneratedColliderSettings();
         [HideInInspector, SerializeField] CSGGeneratedRenderSettings    renderSettings      = new CSGGeneratedRenderSettings();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Box/Editor/ChiselBoxGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Box/Editor/ChiselBoxGeneratorMode.cs
@@ -52,7 +52,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    box = ChiselModelManager.Create<ChiselBox>("Box",
+                    box = ChiselComponentFactory.Create<ChiselBox>("Box",
                                                       ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                       transformation);
                     box.Operation = forceOperation ?? CSGOperationType.Additive;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Box/Editor/ChiselBoxGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Box/Editor/ChiselBoxGeneratorMode.cs
@@ -53,7 +53,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     box = ChiselComponentFactory.Create<ChiselBox>("Box",
-                                                      ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                      ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                       transformation);
                     box.Operation = forceOperation ?? CSGOperationType.Additive;
                     box.Bounds = bounds;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Capsule/Editor/ChiselCapsuleGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Capsule/Editor/ChiselCapsuleGeneratorMode.cs
@@ -61,7 +61,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     capsule = ChiselComponentFactory.Create<ChiselCapsule>("Capsule",
-                                                                ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                                ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                                 transformation);
                     capsule.definition.Reset();
                     capsule.Operation       = forceOperation ?? CSGOperationType.Additive;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Capsule/Editor/ChiselCapsuleGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Capsule/Editor/ChiselCapsuleGeneratorMode.cs
@@ -60,7 +60,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    capsule = ChiselModelManager.Create<ChiselCapsule>("Capsule",
+                    capsule = ChiselComponentFactory.Create<ChiselCapsule>("Capsule",
                                                                 ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                                 transformation);
                     capsule.definition.Reset();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Cylinder/Editor/ChiselCylinderGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Cylinder/Editor/ChiselCylinderGeneratorMode.cs
@@ -55,7 +55,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    cylinder = ChiselModelManager.Create<ChiselCylinder>("Cylinder",
+                    cylinder = ChiselComponentFactory.Create<ChiselCylinder>("Cylinder",
                                                                 ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                                 transformation);
                     cylinder.definition.Reset();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Cylinder/Editor/ChiselCylinderGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Cylinder/Editor/ChiselCylinderGeneratorMode.cs
@@ -56,7 +56,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     cylinder = ChiselComponentFactory.Create<ChiselCylinder>("Cylinder",
-                                                                ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                                ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                                 transformation);
                     cylinder.definition.Reset();
                     cylinder.Operation			= forceOperation ?? CSGOperationType.Additive;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/ExtrudedShape/Editor/ChiselExtrudedShapeGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/ExtrudedShape/Editor/ChiselExtrudedShapeGeneratorMode.cs
@@ -48,7 +48,7 @@ namespace Chisel.Editors
                 {
                     var center2D = shape.Center;
                     var center3D = new Vector3(center2D.x, 0, center2D.y);
-                    extrudedShape = ChiselModelManager.Create<ChiselExtrudedShape>("Extruded Shape",
+                    extrudedShape = ChiselComponentFactory.Create<ChiselExtrudedShape>("Extruded Shape",
                                                                           ChiselModelManager.GetModelForNode(modelBeneathCursor), 
                                                                           transformation * Matrix4x4.TRS(center3D, Quaternion.identity, Vector3.one));
                     shape.Center = Vector2.zero;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/ExtrudedShape/Editor/ChiselExtrudedShapeGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/ExtrudedShape/Editor/ChiselExtrudedShapeGeneratorMode.cs
@@ -49,7 +49,7 @@ namespace Chisel.Editors
                     var center2D = shape.Center;
                     var center3D = new Vector3(center2D.x, 0, center2D.y);
                     extrudedShape = ChiselComponentFactory.Create<ChiselExtrudedShape>("Extruded Shape",
-                                                                          ChiselModelManager.GetModelForNode(modelBeneathCursor), 
+                                                                          ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor), 
                                                                           transformation * Matrix4x4.TRS(center3D, Quaternion.identity, Vector3.one));
                     shape.Center = Vector2.zero;
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Hemisphere/Editor/ChiselHemisphereGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Hemisphere/Editor/ChiselHemisphereGeneratorMode.cs
@@ -56,7 +56,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    hemisphere = ChiselModelManager.Create<ChiselHemisphere>("Hemisphere",
+                    hemisphere = ChiselComponentFactory.Create<ChiselHemisphere>("Hemisphere",
                                                                 ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                                 transformation);
                     hemisphere.definition.Reset();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Hemisphere/Editor/ChiselHemisphereGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Hemisphere/Editor/ChiselHemisphereGeneratorMode.cs
@@ -57,7 +57,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     hemisphere = ChiselComponentFactory.Create<ChiselHemisphere>("Hemisphere",
-                                                                ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                                ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                                 transformation);
                     hemisphere.definition.Reset();
                     hemisphere.Operation            = forceOperation ?? CSGOperationType.Additive;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/LinearStairs/Editor/ChiselLinearStairsGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/LinearStairs/Editor/ChiselLinearStairsGeneratorMode.cs
@@ -48,7 +48,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     linearStairs = ChiselComponentFactory.Create<ChiselLinearStairs>("Linear Stairs",
-                                                                        ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                                        ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                                         transformation);
                     linearStairs.definition.Reset();
                     linearStairs.Operation  = forceOperation ?? CSGOperationType.Additive;

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/LinearStairs/Editor/ChiselLinearStairsGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/LinearStairs/Editor/ChiselLinearStairsGeneratorMode.cs
@@ -47,7 +47,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    linearStairs = ChiselModelManager.Create<ChiselLinearStairs>("Linear Stairs",
+                    linearStairs = ChiselComponentFactory.Create<ChiselLinearStairs>("Linear Stairs",
                                                                         ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                                         transformation);
                     linearStairs.definition.Reset();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Sphere/Editor/ChiselSphereGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Sphere/Editor/ChiselSphereGeneratorMode.cs
@@ -59,7 +59,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    sphere = ChiselModelManager.Create<ChiselSphere>("Sphere",
+                    sphere = ChiselComponentFactory.Create<ChiselSphere>("Sphere",
                                                                 ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                                 transformation);
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Sphere/Editor/ChiselSphereGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/Sphere/Editor/ChiselSphereGeneratorMode.cs
@@ -60,7 +60,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     sphere = ChiselComponentFactory.Create<ChiselSphere>("Sphere",
-                                                                ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                                ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                                 transformation);
 
                     sphere.definition.Reset();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/SpiralStairs/Editor/ChiselSpiralStairsGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/SpiralStairs/Editor/ChiselSpiralStairsGeneratorMode.cs
@@ -56,7 +56,7 @@ namespace Chisel.Editors
             {
                 case BoxExtrusionState.Create:
                 {
-                    spiralStairs = ChiselModelManager.Create<ChiselSpiralStairs>("Spiral Stairs",
+                    spiralStairs = ChiselComponentFactory.Create<ChiselSpiralStairs>("Spiral Stairs",
                                                                         ChiselModelManager.GetModelForNode(modelBeneathCursor),
                                                                         transformation);
                     spiralStairs.definition.Reset();

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/SpiralStairs/Editor/ChiselSpiralStairsGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Generators/SpiralStairs/Editor/ChiselSpiralStairsGeneratorMode.cs
@@ -57,7 +57,7 @@ namespace Chisel.Editors
                 case BoxExtrusionState.Create:
                 {
                     spiralStairs = ChiselComponentFactory.Create<ChiselSpiralStairs>("Spiral Stairs",
-                                                                        ChiselModelManager.GetModelForNode(modelBeneathCursor),
+                                                                        ChiselModelManager.GetActiveModelOrCreate(modelBeneathCursor),
                                                                         transformation);
                     spiralStairs.definition.Reset();
                     spiralStairs.Operation		= forceOperation ?? CSGOperationType.Additive;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/ChiselUnityEventsManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/ChiselUnityEventsManager.cs
@@ -266,7 +266,7 @@ namespace Chisel.Editors
             var component = gameObject.GetComponent<ChiselNode>();
             if (!component)
                 return;
-            Editors.ChiselHierarchyWindowManager.OnHierarchyWindowItemGUI(component, selectionRect);
+            Editors.ChiselHierarchyWindowManager.OnHierarchyWindowItemGUI(instanceID, component, selectionRect);
         }
 
         private static void OnPlayModeStateChanged(PlayModeStateChange state)

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Hierarchy/ChiselHierarchyWindowManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Hierarchy/ChiselHierarchyWindowManager.cs
@@ -24,17 +24,36 @@ namespace Chisel.Editors
             selectionRect.y--;
             GUI.Label(selectionRect, icon);
         }
-
-        internal static void OnHierarchyWindowItemGUI(ChiselNode node, Rect selectionRect)
+        
+        static void RenderHierarchyItem(int instanceID, ChiselNode node, Rect selectionRect)
         {
-            // TODO: implement material drag & drop support on hierarchy items
+            var model = node as ChiselModel;
+            if (!ReferenceEquals(model, null))
+            {
+                if (model == ChiselModelManager.ActiveModel)
+                {
+                    const float kIconSize     = 13;
+                    const float kOffsetToText = kIconSize + 28;
 
-            if (Event.current.type != EventType.Repaint)
-                return;
+                    var rect = selectionRect;
+                    rect.xMin += kOffsetToText;
+
+                    var content     = EditorGUIUtility.TrTempContent(node.name + "*");
+                    GUI.Label(rect, content, EditorStyles.label);
+                }
+            }
 
             var icon = ChiselNodeDetailsManager.GetHierarchyIcon(node);
             if (icon != null)
                 RenderIcon(selectionRect, icon);
+        }
+
+        internal static void OnHierarchyWindowItemGUI(int instanceID, ChiselNode node, Rect selectionRect)
+        {
+            // TODO: implement material drag & drop support on hierarchy items
+
+            if (Event.current.type == EventType.Repaint)
+                RenderHierarchyItem(instanceID, node, selectionRect);
         }
     }
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Hierarchy/ChiselHierarchyWindowManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Hierarchy/ChiselHierarchyWindowManager.cs
@@ -33,13 +33,18 @@ namespace Chisel.Editors
                 if (model == ChiselModelManager.ActiveModel)
                 {
                     const float kIconSize     = 13;
-                    const float kOffsetToText = kIconSize + 28;
+                    const float kOffsetToText = kIconSize + 27.0f;
 
                     var rect = selectionRect;
                     rect.xMin += kOffsetToText;
 
-                    var content     = EditorGUIUtility.TrTempContent(node.name + "*");
-                    GUI.Label(rect, content, EditorStyles.label);
+                    var content     = EditorGUIUtility.TrTempContent(node.name + " (active)");
+
+                    // TODO: figure out correct color depending on selection and proSkin
+
+                    GUI.Label(rect, content);
+                    rect.xMin += 0.5f;
+                    GUI.Label(rect, content);
                 }
             }
 


### PR DESCRIPTION
This PR adds the ability to set an active model to which all new brushes are added

this fixes #65 and implements task #88 