### PR TITLE
UVMatrix propertyDrawer update

### DIFF
--- a/Packages/com.chisel.core/Chisel/Core/API.public/BrushMesh.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/BrushMesh.cs
@@ -18,37 +18,6 @@ namespace Chisel.Core
         TextureIsInWorldSpace = 1
     }
 
-    /// <summary>A 2x4 matrix to calculate the UV coordinates for the vertices of a <see cref="Chisel.Core.BrushMesh"/>.</summary>
-    /// <seealso cref="Chisel.Core.BrushMesh.Polygon"/>
-    /// <seealso cref="Chisel.Core.BrushMesh"/>
-    [Serializable, StructLayout(LayoutKind.Sequential, Pack = 4)]
-    public struct UVMatrix
-    {
-        public UVMatrix(Matrix4x4 input) { U = input.GetRow(0); V = input.GetRow(1); }
-        public UVMatrix(Vector4 u, Vector4 v) { U = u; V = v; }
-
-        /// <value>Used to convert a vertex coordinate to a U texture coordinate</value>
-        public Vector4 U;
-
-        /// <value>Used to convert a vertex coordinate to a V texture coordinate</value>
-        public Vector4 V;
-
-
-        // TODO: add description
-        public Matrix4x4 ToMatrix() { var W = Vector3.Cross(U, V); return new Matrix4x4(U, V, W, new Vector4(0, 0, 0, 1)).transpose; }
-
-        // TODO: add description
-        public UVMatrix Set(Matrix4x4 input) { U = input.GetRow(0); V = input.GetRow(1); return this; }
-
-        // TODO: add description
-        public static implicit operator Matrix4x4(UVMatrix input) { return input.ToMatrix(); }
-        public static implicit operator UVMatrix(Matrix4x4 input) { return new UVMatrix(input); }
-
-        // TODO: add description
-        public static readonly UVMatrix identity = new UVMatrix(new Vector4(1,0,0,0.0f), new Vector4(0,1,0,0.0f));
-        public static readonly UVMatrix centered = new UVMatrix(new Vector4(1,0,0,0.5f), new Vector4(0,1,0,0.5f));
-    }
-    
     // Separate struct so that we can create a property drawer for it
     [Serializable, StructLayout(LayoutKind.Sequential, Pack = 4)]
     public struct SmoothingGroup

--- a/Packages/com.chisel.core/Chisel/Core/API.public/UVMatrix.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/UVMatrix.cs
@@ -39,13 +39,13 @@ namespace Chisel.Core
 
         public static UVMatrix TRS(Vector2 translation, Vector3 normal, float rotation, Vector2 scale)
         {
-            var orientation     = Quaternion.Inverse(Quaternion.LookRotation(normal, Vector3.forward));
+            var orientation     = Quaternion.Inverse(Quaternion.LookRotation(normal));
             var rotation2d      = Quaternion.AngleAxis(rotation, Vector3.forward);
             var scale3d         = new Vector3(scale.x, scale.y, 1.0f);
 
             // TODO: optimize
             return (UVMatrix)
-                    (Matrix4x4.TRS(rotation2d * translation, Quaternion.identity, Vector3.one) *
+                    (Matrix4x4.TRS(translation, Quaternion.identity, Vector3.one) *
                      Matrix4x4.TRS(Vector3.zero, Quaternion.identity, scale3d) *
                      Matrix4x4.TRS(Vector3.zero, rotation2d, Vector3.one) *
 
@@ -53,31 +53,37 @@ namespace Chisel.Core
         }
         
         public void Decompose(out Vector2 translation, out Vector3 normal, out float rotation, out Vector2 scale)
-        {            
+        {
             normal              = planeNormal;
-            var orientation     = Quaternion.LookRotation(normal, Vector3.forward);
+            var orientation     = Quaternion.LookRotation(normal);
             var inv_orientation = Quaternion.Inverse(orientation);
 
             var u = inv_orientation * (Vector3)U;
             var v = inv_orientation * (Vector3)V;
-            
-            rotation        = -Vector3.SignedAngle(Vector3.right, u, Vector3.forward);
+
+            rotation = -Vector3.SignedAngle(Vector3.right, u, Vector3.forward);
 
             const double min_rotate = 1.0 / 10000.0;
             rotation = (float)(Math.Round(rotation / min_rotate) * min_rotate);
 
-            scale           = new Vector2(u.magnitude, v.magnitude);
+            scale = new Vector2(u.magnitude, v.magnitude);
 
             const double min_scale = 1.0 / 10000.0;
             scale.x = (float)(Math.Round(scale.x / min_scale) * min_scale);
             scale.y = (float)(Math.Round(scale.y / min_scale) * min_scale);
 
             var rotation2d  = Quaternion.AngleAxis(-rotation, Vector3.forward);
-            translation     = rotation2d * new Vector2(U.w, V.w);
+            translation     = new Vector2(U.w, V.w);
 
             const double min_translation = 1.0 / 32768.0;
             translation.x = (float)(Math.Round(translation.x / min_translation) * min_translation);
             translation.y = (float)(Math.Round(translation.y / min_translation) * min_translation);
+
+
+            // TODO: figure out a better way to find if we scale negatively
+            var newUvMatrix = UVMatrix.TRS(translation, normal, rotation, scale);
+            if (Vector3.Dot(V, newUvMatrix.V) < 0) scale.y = -scale.y;
+            if (Vector3.Dot(U, newUvMatrix.U) < 0) scale.x = -scale.x;
         }
 
         public override string ToString()

--- a/Packages/com.chisel.core/Chisel/Core/API.public/UVMatrix.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/UVMatrix.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace Chisel.Core
+{
+    /// <summary>A 2x4 matrix to calculate the UV coordinates for the vertices of a <see cref="Chisel.Core.BrushMesh"/>.</summary>
+    /// <seealso cref="Chisel.Core.BrushMesh.Polygon"/>
+    /// <seealso cref="Chisel.Core.BrushMesh"/>
+    [Serializable, StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct UVMatrix
+    {
+        public UVMatrix(Matrix4x4 input) { U = input.GetRow(0); V = input.GetRow(1); }
+        public UVMatrix(Vector4 u, Vector4 v) { U = u; V = v; }
+
+        /// <value>Used to convert a vertex coordinate to a U texture coordinate</value>
+        public Vector4 U;
+
+        /// <value>Used to convert a vertex coordinate to a V texture coordinate</value>
+        public Vector4 V;
+
+
+        // TODO: add description
+        public Matrix4x4 ToMatrix() { var W = planeNormal; return new Matrix4x4(U, V, W, new Vector4(0, 0, 0, 1)).transpose; }
+
+        public Vector3 planeNormal { get { return Vector3.Cross(((Vector3)U).normalized, ((Vector3)V).normalized).normalized; } }
+
+        // TODO: add description
+        public UVMatrix Set(Matrix4x4 input) { U = input.GetRow(0); V = input.GetRow(1); return this; }
+
+        // TODO: add description
+        public static implicit operator Matrix4x4(UVMatrix input) { return input.ToMatrix(); }
+        public static implicit operator UVMatrix(Matrix4x4 input) { return new UVMatrix(input); }
+
+        // TODO: add description
+        public static readonly UVMatrix identity = new UVMatrix(new Vector4(1,0,0,0.0f), new Vector4(0,1,0,0.0f));
+        public static readonly UVMatrix centered = new UVMatrix(new Vector4(1,0,0,0.5f), new Vector4(0,1,0,0.5f));
+
+        public static UVMatrix TRS(Vector2 translation, Vector3 normal, float rotation, Vector2 scale)
+        {
+            var orientation = Quaternion.Inverse(Quaternion.LookRotation(normal, Vector3.forward));
+            var rotation2d  = Quaternion.AngleAxis(rotation, Vector3.forward);
+            var scale3d     = new Vector3(scale.x, scale.y, 1.0f);
+
+            return (UVMatrix)
+                    (Matrix4x4.TRS(translation, rotation2d, scale3d) *
+                    Matrix4x4.TRS(Vector3.zero, orientation, Vector3.one));
+        }
+        
+        public void Decompose(out Vector2 translation, out Vector3 normal, out float rotation, out Vector2 scale)
+        {            
+            normal              = planeNormal;
+            var orientation     = Quaternion.LookRotation(normal, Vector3.forward);
+            
+            // TODO: simplify this part to not require a Matrix4x4
+            var transform = ToMatrix();
+            transform.SetColumn(3, new Vector4(0, 0, 0, 1));
+            transform *= Matrix4x4.TRS(Vector3.zero, orientation, Vector3.one);
+            var u = transform.MultiplyVector(Vector3.right);
+            var v = transform.MultiplyVector(Vector3.up);
+            
+            rotation        = Vector3.SignedAngle(Vector3.right, u, Vector3.forward);
+            scale           = new Vector2(u.magnitude, v.magnitude);
+            translation     = new Vector2(U.w, V.w);
+        }
+
+        public override string ToString()
+        {
+            return $@"{{U: {U}, V: {V}}}";  
+        }
+    }
+}

--- a/Packages/com.chisel.core/Chisel/Core/API.public/UVMatrix.cs.meta
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/UVMatrix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd7382484a8d0e2469f8419548cf3bff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.chisel.editor/Chisel/Editor/Components/Base/Editor/PropertyDrawers/UVMatrixPropertyDrawer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Components/Base/Editor/PropertyDrawers/UVMatrixPropertyDrawer.cs
@@ -12,13 +12,13 @@ namespace Chisel.Editors
     [CustomPropertyDrawer(typeof(UVMatrix))]
     public sealed class UVMatrixPropertyDrawer : PropertyDrawer
     {
-        const float kSpace = 2;
+        const float kSpacing = 2;
 
         public static float DefaultHeight
         {
             get
             {
-                return kSpace + (2 * EditorGUI.GetPropertyHeight(SerializedPropertyType.Vector4, GUIContent.none));
+                return (2 * (kSpacing + EditorGUI.GetPropertyHeight(SerializedPropertyType.Vector2, GUIContent.none))) + EditorGUI.GetPropertyHeight(SerializedPropertyType.Float, GUIContent.none);
             }
         }
 
@@ -27,6 +27,7 @@ namespace Chisel.Editors
             return DefaultHeight;
         }
 
+        /*
         static readonly GUIContent[] xyzw = new []
         {
             new GUIContent("X"),
@@ -34,10 +35,55 @@ namespace Chisel.Editors
             new GUIContent("Z"),
             new GUIContent("W"),
         };
+        */
+        static readonly GUIContent kTranslationContent  = new GUIContent("Translation");
+        static readonly GUIContent kScaleContent        = new GUIContent("Scale");
+        static readonly GUIContent kRotationContent     = new GUIContent("Rotation");
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            // TODO: decompose uv matrix into translation, rotation and scale relative to it's plane (cross product of u/v is normal)
+            SerializedProperty UProp    = property.FindPropertyRelative(nameof(UVMatrix.U));
+            SerializedProperty VProp    = property.FindPropertyRelative(nameof(UVMatrix.V));
+
+            var uvMatrix = new UVMatrix(UProp.vector4Value, VProp.vector4Value);
+
+            uvMatrix.Decompose(out Vector2 translation, out Vector3 normal, out float rotation, out Vector2 scale);
+
+            EditorGUI.BeginProperty(position, label, property);
+            {
+                EditorGUI.BeginChangeCheck();
+
+                var prevMixedValues = EditorGUI.showMixedValue;
+                EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
+
+                var translationContent  = (label == null) ? GUIContent.none : kTranslationContent;
+                var scaleContent        = (label == null) ? GUIContent.none : kScaleContent;
+                var rotationContent     = (label == null) ? GUIContent.none : kRotationContent;
+
+                position.height = EditorGUI.GetPropertyHeight(SerializedPropertyType.Vector2, GUIContent.none);
+                translation = EditorGUI.Vector2Field(position,  translationContent, translation);
+                position.y += position.height + kSpacing;
+
+                position.height = EditorGUI.GetPropertyHeight(SerializedPropertyType.Vector2, GUIContent.none);
+                scale = EditorGUI.Vector2Field(position,        scaleContent,       scale);
+                position.y += position.height + kSpacing;
+
+                position.height = EditorGUI.GetPropertyHeight(SerializedPropertyType.Float, GUIContent.none);
+                rotation = EditorGUI.FloatField(position,       rotationContent,    rotation);
+                position.y += position.height + kSpacing;
+
+                EditorGUI.showMixedValue = prevMixedValues;
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    uvMatrix = UVMatrix.TRS(translation, normal, rotation, scale);
+                    UProp.vector4Value = uvMatrix.U;
+                    VProp.vector4Value = uvMatrix.V;
+                    property.serializedObject.ApplyModifiedProperties();
+                }
+            }
+            EditorGUI.EndProperty();
+            /*
             
             SerializedProperty UxProp   = property.FindPropertyRelative($"{nameof(UVMatrix.U)}.{nameof(UVMatrix.U.x)}");
             SerializedProperty VxProp   = property.FindPropertyRelative($"{nameof(UVMatrix.V)}.{nameof(UVMatrix.V.x)}");
@@ -53,6 +99,7 @@ namespace Chisel.Editors
                 EditorGUI.MultiPropertyField(position, xyzw, VxProp);
             }
             EditorGUI.EndProperty();
+            */
         }
     }
 }


### PR DESCRIPTION
The property drawer for the UVMatrix class now decomposes the UV matrix into rotation, scale and rotation and shows that. When the user modifies one of these values, the UVMatrix is updated accordingly
![uvmatrix](https://user-images.githubusercontent.com/157976/58761901-6bd8fc00-8549-11e9-94a2-90c3c58ee682.gif)
