### PR TITLE
Fixed material names and usage on spiral stairs

### DIFF
--- a/Packages/com.chisel.components/Package Resources/Floor.mat
+++ b/Packages/com.chisel.components/Package Resources/Floor.mat
@@ -40,7 +40,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: c68a4dd04a6cece419efd8f8960b95e9, type: 3}
+        m_Texture: {fileID: 2800000, guid: 784fe6fc9c8a7664f8d311045a5ce532, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/BrushFactory.Shapes.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/BrushFactory.Shapes.cs
@@ -174,7 +174,7 @@ namespace Chisel.Core
                 new BrushMesh.Polygon { surfaceID = 1, firstEdge =  3, edgeCount = 3, surface = surfaces[1] },
                 new BrushMesh.Polygon { surfaceID = 2, firstEdge =  6, edgeCount = 4, surface = surfaces[2] },
                 new BrushMesh.Polygon { surfaceID = 3, firstEdge = 10, edgeCount = 4, surface = surfaces[3] },
-                new BrushMesh.Polygon { surfaceID = 4, firstEdge = 14, edgeCount = 4, surface = surfaces[0] } // TODO: figure out why this is [0]
+                new BrushMesh.Polygon { surfaceID = 4, firstEdge = 14, edgeCount = 4, surface = surfaces[4] }
             };
         }
 

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/BrushFactory.SpiralStairs.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/BrushFactory.SpiralStairs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Vector2 = UnityEngine.Vector2;
 using Vector3 = UnityEngine.Vector3;
@@ -86,6 +86,48 @@ namespace Chisel.Core
             var outerSides		= definition.outerSegments;
             var riserDepth		= definition.riserDepth;
 
+            var treadSurfaceDefinition = new ChiselSurfaceDefinition();
+            treadSurfaceDefinition.EnsureSize(6);
+            treadSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadTopSurface];
+            treadSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadBottomSurface];
+            treadSurfaceDefinition.surfaces[2] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadBackSurface];
+            treadSurfaceDefinition.surfaces[3] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadFrontSurface];
+            treadSurfaceDefinition.surfaces[4] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kInnerSurface];
+            treadSurfaceDefinition.surfaces[5] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kOuterSurface];
+
+            var riserSurfaceDefinition = new ChiselSurfaceDefinition();
+            riserSurfaceDefinition.EnsureSize(6);
+            riserSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kOuterSurface];
+            riserSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kInnerSurface];
+            riserSurfaceDefinition.surfaces[2] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadTopSurface];
+            riserSurfaceDefinition.surfaces[3] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadBottomSurface];
+            riserSurfaceDefinition.surfaces[4] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kRiserBackSurface];
+            riserSurfaceDefinition.surfaces[5] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kRiserFrontSurface];
+
+            var riserWedgeSurfaceDefinition = new ChiselSurfaceDefinition();
+            riserWedgeSurfaceDefinition.EnsureSize(6);
+            
+            riserWedgeSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadTopSurface];
+            riserWedgeSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kTreadBottomSurface];
+            riserWedgeSurfaceDefinition.surfaces[2] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kRiserFrontSurface];
+            riserWedgeSurfaceDefinition.surfaces[3] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kRiserBackSurface];
+            riserWedgeSurfaceDefinition.surfaces[4] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kOuterSurface];
+                       
+
+            var outerCylinderSurfaceDefinition = new ChiselSurfaceDefinition();
+            outerCylinderSurfaceDefinition.EnsureSize(outerSides + 2);
+            for (int i = 0; i < outerCylinderSurfaceDefinition.surfaces.Length; i++)
+                outerCylinderSurfaceDefinition.surfaces[i] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kOuterSurface];
+
+            ChiselSurfaceDefinition innerCylinderSurfaceDefinition = null;
+            if (haveInnerCyl)
+            {
+                innerCylinderSurfaceDefinition = new ChiselSurfaceDefinition();
+                innerCylinderSurfaceDefinition.EnsureSize(innerSides + 2);
+                for (int i = 0; i < innerCylinderSurfaceDefinition.surfaces.Length; i++)
+                    innerCylinderSurfaceDefinition.surfaces[i] = surfaceDefinition.surfaces[ChiselSpiralStairsDefinition.kInnerSurface];
+            }
+
             brushContainer.EnsureSize(subMeshCount);
 
             if (haveRiser)
@@ -129,7 +171,7 @@ namespace Chisel.Core
                         ref var brushMesh = ref brushContainer.brushMeshes[i];
                         if (i == 0)
                         {
-                            brushMesh.polygons = BrushMeshFactory.CreateBoxPolygons(surfaceDefinition);
+                            brushMesh.polygons = BrushMeshFactory.CreateBoxPolygons(riserSurfaceDefinition);
                             minY -= treadHeight;
                         } else
                         {
@@ -209,7 +251,7 @@ namespace Chisel.Core
                                 ref var brushMesh = ref brushContainer.brushMeshes[subMeshIndex];
                                 if (i == 0)
                                 {
-                                    brushMesh.polygons = BrushMeshFactory.CreateSquarePyramidAssetPolygons(surfaceDefinition);
+                                    brushMesh.polygons = BrushMeshFactory.CreateSquarePyramidAssetPolygons(treadSurfaceDefinition);
                                 } else
                                 {
                                     brushMesh.polygons = brushContainer.brushMeshes[subMeshIndex - i].polygons.ToArray();
@@ -231,7 +273,7 @@ namespace Chisel.Core
                                 ref var brushMesh = ref brushContainer.brushMeshes[subMeshIndex];
                                 if (i == 0)
                                 {
-                                    brushMesh.polygons = BrushMeshFactory.CreateTriangularPyramidAssetPolygons(surfaceDefinition);
+                                    brushMesh.polygons = BrushMeshFactory.CreateTriangularPyramidAssetPolygons(treadSurfaceDefinition);
                                 } else
                                 {
                                     brushMesh.polygons = brushContainer.brushMeshes[subMeshIndex - i].polygons.ToArray();
@@ -257,7 +299,7 @@ namespace Chisel.Core
                             ref var brushMesh = ref brushContainer.brushMeshes[subMeshIndex];
                             if (i == 0)
                             {
-                                brushMesh.polygons = BrushMeshFactory.CreateTriangularPyramidAssetPolygons(surfaceDefinition);
+                                brushMesh.polygons = BrushMeshFactory.CreateTriangularPyramidAssetPolygons(treadSurfaceDefinition);
                             } else
                             {
                                 brushMesh.polygons = brushContainer.brushMeshes[subMeshIndex - i].polygons.ToArray();
@@ -279,7 +321,7 @@ namespace Chisel.Core
                             ref var brushMesh = ref brushContainer.brushMeshes[subMeshIndex];
                             if (i == 0)
                             {
-                                brushMesh.polygons = BrushMeshFactory.CreateTriangularPyramidAssetPolygons(surfaceDefinition);
+                                brushMesh.polygons = BrushMeshFactory.CreateTriangularPyramidAssetPolygons(treadSurfaceDefinition);
                             } else
                             {
                                 brushMesh.polygons = brushContainer.brushMeshes[subMeshIndex - i].polygons.ToArray();
@@ -327,7 +369,7 @@ namespace Chisel.Core
                         ref var brushMesh = ref brushContainer.brushMeshes[i];
                         if (i == 0)
                         {
-                            brushMesh.polygons = BrushMeshFactory.CreateWedgeAssetPolygons(surfaceDefinition);
+                            brushMesh.polygons = BrushMeshFactory.CreateWedgeAssetPolygons(riserWedgeSurfaceDefinition);
                             minY -= treadHeight;
                         } else
                         {
@@ -344,28 +386,16 @@ namespace Chisel.Core
                 
                 {
                     var subMeshIndex = treadStart - cylinderSubMeshCount;
-                    var cylinderSurfaceDefinition   = new ChiselSurfaceDefinition();
-                    cylinderSurfaceDefinition.EnsureSize(outerSides + 2);
-                    cylinderSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[0];
-                    cylinderSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[1];
-                    for (int i = 2; i < cylinderSurfaceDefinition.surfaces.Length; i++)
-                        cylinderSurfaceDefinition.surfaces[i] = surfaceDefinition.surfaces[2];
                     
-                    BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], outerDiameter, origin.y, origin.y + height, 0, outerSides, cylinderSurfaceDefinition);
+                    BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], outerDiameter, origin.y, origin.y + height, 0, outerSides, outerCylinderSurfaceDefinition);
                     brushContainer.operations[subMeshIndex] = CSGOperationType.Intersecting;
                 }
 
                 if (haveInnerCyl)
                 {
                     var subMeshIndex = treadStart - 1;
-                    var cylinderSurfaceDefinition   = new ChiselSurfaceDefinition();
-                    cylinderSurfaceDefinition.EnsureSize(innerSides + 2);
-                    cylinderSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[0];
-                    cylinderSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[1];
-                    for (int i = 2; i < cylinderSurfaceDefinition.surfaces.Length; i++)
-                        cylinderSurfaceDefinition.surfaces[i] = surfaceDefinition.surfaces[2];
 
-                    BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], innerDiameter, origin.y, origin.y + height, 0, innerSides, cylinderSurfaceDefinition);
+                    BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], innerDiameter, origin.y, origin.y + height, 0, innerSides, innerCylinderSurfaceDefinition);
                     brushContainer.operations[subMeshIndex] = CSGOperationType.Subtractive;
                 }
 
@@ -411,7 +441,7 @@ namespace Chisel.Core
                     ref var brushMesh = ref brushContainer.brushMeshes[i];
                     if (n == 0)
                     {
-                        brushMesh.polygons = BrushMeshFactory.CreateBoxPolygons(surfaceDefinition);
+                        brushMesh.polygons = BrushMeshFactory.CreateBoxPolygons(treadSurfaceDefinition);
                     } else
                         brushMesh.polygons = brushContainer.brushMeshes[startIndex].polygons.ToArray();
 
@@ -426,28 +456,15 @@ namespace Chisel.Core
 
             {
                 var subMeshIndex = subMeshCount - cylinderSubMeshCount;
-                var cylinderSurfaceDefinition   = new ChiselSurfaceDefinition();
-                cylinderSurfaceDefinition.EnsureSize(outerSides + 2);
-                cylinderSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[0];
-                cylinderSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[1];
-                for (int i = 2; i < cylinderSurfaceDefinition.surfaces.Length; i++)
-                    cylinderSurfaceDefinition.surfaces[i] = surfaceDefinition.surfaces[2];
-                
-                BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], outerDiameter + nosingWidth, origin.y, origin.y + height, 0, outerSides, cylinderSurfaceDefinition);
+
+                BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], outerDiameter + nosingWidth, origin.y, origin.y + height, 0, outerSides, outerCylinderSurfaceDefinition);
                 brushContainer.operations[subMeshIndex] = CSGOperationType.Intersecting;
             }
 
             if (haveInnerCyl)
             {
                 var subMeshIndex = subMeshCount - 1;
-                var cylinderSurfaceDefinition   = new ChiselSurfaceDefinition();
-                cylinderSurfaceDefinition.EnsureSize(innerSides + 2);
-                cylinderSurfaceDefinition.surfaces[0] = surfaceDefinition.surfaces[0];
-                cylinderSurfaceDefinition.surfaces[1] = surfaceDefinition.surfaces[1];
-                for (int i = 2; i < cylinderSurfaceDefinition.surfaces.Length; i++)
-                    cylinderSurfaceDefinition.surfaces[i] = surfaceDefinition.surfaces[2];
-
-                BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], innerDiameter - nosingWidth, origin.y, origin.y + height, 0, innerSides, cylinderSurfaceDefinition);
+                BrushMeshFactory.GenerateCylinderSubMesh(ref brushContainer.brushMeshes[subMeshIndex], innerDiameter - nosingWidth, origin.y, origin.y + height, 0, innerSides, innerCylinderSurfaceDefinition);
                 brushContainer.operations[subMeshIndex] = CSGOperationType.Subtractive;
             }
             return true;

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/BrushFactory.SpiralStairs.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/BrushFactory.SpiralStairs.cs
@@ -25,7 +25,7 @@ namespace Chisel.Core
             ref readonly var surfaceDefinition = ref definition.surfaceDefinition;
             if (surfaceDefinition == null ||
                 surfaceDefinition.surfaces == null ||
-                surfaceDefinition.surfaces.Length != 6)
+                surfaceDefinition.surfaces.Length < 8)
                 return false;
             
             const float kEpsilon = 0.001f;

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/ChiselSpiralStairsDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/ChiselSpiralStairsDefinition.cs
@@ -16,6 +16,16 @@ namespace Chisel.Core
     [Serializable]
     public struct ChiselSpiralStairsDefinition : IChiselGenerator
     {
+        public const int kTreadTopSurface       = 0;
+        public const int kTreadBottomSurface    = 1;
+        public const int kTreadFrontSurface     = 2;
+        public const int kTreadBackSurface      = 3;
+        public const int kRiserFrontSurface     = 4;
+        public const int kRiserBackSurface      = 5;
+        public const int kInnerSurface          = 6;
+        public const int kOuterSurface          = 7;
+
+
         public const float	kMinStepHeight			= 0.01f;
         public const float  kMinStairsDepth         = 0.1f;
         public const float  kMinRiserDepth          = 0.01f;

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/ChiselSpiralStairsDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/ChiselSpiralStairsDefinition.cs
@@ -128,7 +128,7 @@ namespace Chisel.Core
             innerSegments	= Mathf.Max(kMinSegments, innerSegments);
             outerSegments	= Mathf.Max(kMinSegments, outerSegments);
             
-            surfaceDefinition.EnsureSize(6);
+            surfaceDefinition.EnsureSize(8);
         }
 
         public bool Generate(ref ChiselBrushContainer brushContainer)

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
@@ -24,14 +24,14 @@ namespace Chisel.Editors
 
         static readonly GUIContent[] kSurfaceContentNames = new[]
         {
-            new GUIContent("Top"),
-            new GUIContent("Bottom"),
+            new GUIContent("Tread Top"),
+            new GUIContent("Tread Bottom"),
+            new GUIContent("Tread Front"),
+            new GUIContent("Tread Back"),
+            new GUIContent("Riser Front"),
+            new GUIContent("Riser Back"),
             new GUIContent("Inner"),
             new GUIContent("Outer"),
-            new GUIContent("Front"),
-            new GUIContent("Back"),
-            new GUIContent("Tread"),
-            new GUIContent("Step")
         };
 
         SerializedProperty heightProp;


### PR DESCRIPTION
Fixes a warning on the spiral stairs generator and that the materials on the spiral stairs are named correctly and put on the correct sides of the generated brushes