### PR TITLE
Generator/cleanup

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/ChiselModelManager.cs
@@ -6,6 +6,8 @@ namespace Chisel.Components
 {
     public class ChiselModelManager : ScriptableObject
     {
+        const string kDefaultModelName = "Model";
+
         #region Instance
         static ChiselModelManager _instance;
         public static ChiselModelManager Instance
@@ -78,10 +80,15 @@ namespace Chisel.Components
             {
                 // TODO: ensure we create this in the active scene
                 // TODO: handle scene being locked by version control
-                activeModel = ChiselComponentFactory.Create<ChiselModel>("Model");
+                activeModel = CreateNewModel();
                 ChiselModelManager.ActiveModel = activeModel; 
             }
             return activeModel;
+        }
+
+        public static ChiselModel CreateNewModel(Transform parent = null)
+        {
+            return ChiselComponentFactory.Create<ChiselModel>(kDefaultModelName, parent);
         }
 
 #if UNITY_EDITOR

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/ChiselGeneratorComponent.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/ChiselGeneratorComponent.cs
@@ -10,6 +10,8 @@ namespace Chisel.Components
     public abstract class ChiselDefinedGeneratorComponent<DefinitionType> : ChiselGeneratorComponent
         where DefinitionType : IChiselGenerator, new()
     {
+        public const string kDefinitionName = nameof(definition);
+
         [SerializeField] public DefinitionType definition = new DefinitionType();
 
         protected override void OnResetInternal()           { definition.Reset(); base.OnResetInternal(); }
@@ -20,10 +22,10 @@ namespace Chisel.Components
     public abstract class ChiselGeneratorComponent : ChiselNode
     {
         // This ensures names remain identical, or a compile error occurs.
-        public const string kOperationFieldName = nameof(operation);
+        public const string kOperationFieldName         = nameof(operation);
 
         // This ensures names remain identical, or a compile error occurs.
-        public const string kBrushContainerAssetName = nameof(brushContainerAsset);
+        public const string kBrushContainerAssetName    = nameof(brushContainerAsset);
 
 
         [HideInInspector] CSGTreeNode[] Nodes = new CSGTreeNode[] { new CSGTreeBrush() };

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselModel.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselModel.cs
@@ -108,10 +108,6 @@ namespace Chisel.Components
     {
         public const string kNodeTypeName = "Model";
         public override string NodeTypeName { get { return kNodeTypeName; } }
-        
-        [ContextMenu("Set Active Model")]
-        void SetActiveModel() { ChiselModelManager.ActiveModel = this; }
-        
 
         [HideInInspector, SerializeField] CSGGeneratedColliderSettings  colliderSettings    = new CSGGeneratedColliderSettings();
         [HideInInspector, SerializeField] CSGGeneratedRenderSettings    renderSettings      = new CSGGeneratedRenderSettings();

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Box/ChiselBoxDefinitions.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Box/ChiselBoxDefinitions.cs
@@ -12,6 +12,8 @@ namespace Chisel.Core
         public static readonly Bounds   kDefaultBounds = new UnityEngine.Bounds(Vector3.zero, Vector3.one);
 
         public UnityEngine.Bounds       bounds;
+
+        [NamedItems("Top", "Bottom", "Right", "Left", "Front", "Back", fixedSize = 6)]
         public ChiselSurfaceDefinition  surfaceDefinition;
         
         public Vector3                  min		{ get { return bounds.min; } set { bounds.min = value; } }

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Brush/BrushDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Brush/BrushDefinition.cs
@@ -9,9 +9,13 @@ namespace Chisel.Core
     public class BrushDefinition : IChiselGenerator
     {
         public BrushMesh                brushOutline;
+
+        [NamedItems(overflow = "Surface {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
         
+        [HideInInspector]
         [SerializeField] bool           isInsideOut = false;
+        [HideInInspector]
         [SerializeField] bool           validState = true;
 
         public bool ValidState { get { return validState; } set { validState = value; } }

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Capsule/ChiselCapsuleDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Capsule/ChiselCapsuleDefinition.cs
@@ -33,7 +33,8 @@ namespace Chisel.Core
         public int                  sides;
         public int                  topSegments;
         public int                  bottomSegments;
-        
+
+        [NamedItems(overflow = "Side {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public bool					haveRoundedTop		{ get { return topSegments > 0 && topHeight > kHeightEpsilon; } }

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Cylinder/ChiselCylinderDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Cylinder/ChiselCylinderDefinition.cs
@@ -55,7 +55,8 @@ namespace Chisel.Core
 
         [AngleValue]
         public float rotation;
-        
+
+        [NamedItems("Top", "Bottom", overflow = "Side {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public float TopDiameterX

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/ExtrudedShape/ChiselExtrudedShapeDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/ExtrudedShape/ChiselExtrudedShapeDefinition.cs
@@ -22,7 +22,8 @@ namespace Chisel.Core
         public Curve2D                  shape;
         public ChiselPath               path;
         public int                      curveSegments;
-        
+
+        [NamedItems(overflow = "Surface {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
         
         public void Reset()

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Hemisphere/ChiselHemisphereDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Hemisphere/ChiselHemisphereDefinition.cs
@@ -20,7 +20,8 @@ namespace Chisel.Core
         public float                rotation; // TODO: useless?
         public int					horizontalSegments;
         public int					verticalSegments;
-        
+
+        [NamedItems("Bottom", overflow = "Side {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public void Reset()

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/LinearStairs/ChiselLinearStairsDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/LinearStairs/ChiselLinearStairsDefinition.cs
@@ -42,7 +42,7 @@ namespace Chisel.Core
             Bottom,
             Left,
             Right,
-            Forward,
+            Front,
             Back,
             Tread,
             Step,
@@ -77,26 +77,29 @@ namespace Chisel.Core
 
         // TODO: add all spiral stairs improvements to linear stairs
 
+        public Bounds bounds;
+
         [DistanceValue] public float	stepHeight;
         [DistanceValue] public float	stepDepth;
 
-        [DistanceValue] public float	plateauHeight;
-
         [DistanceValue] public float	treadHeight;
+
         [DistanceValue] public float	nosingDepth;
         [DistanceValue] public float	nosingWidth;
 
+        [DistanceValue] public float    plateauHeight;
+
+        public StairsRiserType          riserType;
         [DistanceValue] public float	riserDepth;
 
-        [DistanceValue] public float	sideDepth;
-        [DistanceValue] public float	sideWidth;
-        [DistanceValue] public float	sideHeight;
-
-        public Bounds					bounds;
-        public StairsRiserType			riserType;
         public StairsSideType           leftSide;
         public StairsSideType           rightSide;
         
+        [DistanceValue] public float	sideWidth;
+        [DistanceValue] public float	sideHeight;
+        [DistanceValue] public float	sideDepth;
+        
+        [NamedItems("Top", "Bottom", "Left", "Right", "Front", "Back", "Tread", "Step", overflow = "Side {0}", fixedSize = 8)]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public bool     HasVolume
@@ -174,7 +177,7 @@ namespace Chisel.Core
                 surfaceDefinition.surfaces[(int)SurfaceSides.Bottom ].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultFloorMaterial, defaultPhysicsMaterial);
                 surfaceDefinition.surfaces[(int)SurfaceSides.Left   ].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultWallMaterial,  defaultPhysicsMaterial);
                 surfaceDefinition.surfaces[(int)SurfaceSides.Right  ].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultWallMaterial,  defaultPhysicsMaterial);
-                surfaceDefinition.surfaces[(int)SurfaceSides.Forward].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultWallMaterial,  defaultPhysicsMaterial);
+                surfaceDefinition.surfaces[(int)SurfaceSides.Front].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultWallMaterial,  defaultPhysicsMaterial);
                 surfaceDefinition.surfaces[(int)SurfaceSides.Back   ].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultWallMaterial,  defaultPhysicsMaterial);
                 surfaceDefinition.surfaces[(int)SurfaceSides.Tread  ].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultTreadMaterial, defaultPhysicsMaterial);
                 surfaceDefinition.surfaces[(int)SurfaceSides.Step   ].brushMaterial = ChiselBrushMaterial.CreateInstance(CSGMaterialManager.DefaultStepMaterial,  defaultPhysicsMaterial);

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/RevolvedShape/ChiselRevolvedShapeDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/RevolvedShape/ChiselRevolvedShapeDefinition.cs
@@ -19,7 +19,8 @@ namespace Chisel.Core
         public int					revolveSegments;
         public float				startAngle;
         public float				totalAngle;
-        
+
+        [NamedItems(overflow = "Surface {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public void Reset()

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Sphere/ChiselSphereDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Sphere/ChiselSphereDefinition.cs
@@ -23,7 +23,8 @@ namespace Chisel.Core
         public float    rotation; // TODO: useless?
         public int	    horizontalSegments;
         public int	    verticalSegments;
-        
+
+        [NamedItems(overflow = "Side {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public void Reset()

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/ChiselSpiralStairsDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/SpiralStairs/ChiselSpiralStairsDefinition.cs
@@ -67,7 +67,8 @@ namespace Chisel.Core
         public StairsRiserType		    riserType;
 
         public uint					    bottomSmoothingGroup;
-        
+
+        [NamedItems("Tread Top", "Tread Bottom", "Tread Front", "Tread Back", "Riser Front", "Riser Back", "Inner", "Outer", overflow = "Side {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public int StepCount

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Stadium/ChiselStadiumDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Stadium/ChiselStadiumDefinition.cs
@@ -44,7 +44,9 @@ namespace Chisel.Core
         public bool					haveRoundedTop		{ get { return (topLength    > 0) && (topSides    > 1); } }
         public bool					haveRoundedBottom	{ get { return (bottomLength > 0) && (bottomSides > 1); } }
         public bool					haveCenter			{ get { return (length - ((haveRoundedTop ? topLength : 0) + (haveRoundedBottom ? bottomLength : 0))) >= kNoCenterEpsilon; } }
-        
+
+
+        [NamedItems(overflow = "Surface {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public void Reset()

--- a/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Torus/CSGTorusDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/BrushMeshFactory/Torus/CSGTorusDefinition.cs
@@ -27,7 +27,8 @@ namespace Chisel.Core
         public int                  horizontalSegments;
 
         public bool                 fitCircle;
-        
+
+        [NamedItems(overflow = "Surface {0}")]
         public ChiselSurfaceDefinition  surfaceDefinition;
 
         public static float CalcInnerDiameter(float outerDiameter, float tubeWidth)

--- a/Packages/com.chisel.core/Chisel/Core/PropertyDrawers.meta
+++ b/Packages/com.chisel.core/Chisel/Core/PropertyDrawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81f7ac89a42b85c43bbc75b34bf28f1e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.chisel.core/Chisel/Core/PropertyDrawers/NamedItemsAttribute.cs
+++ b/Packages/com.chisel.core/Chisel/Core/PropertyDrawers/NamedItemsAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Chisel.Core
+{
+    public class NamedItemsAttribute : PropertyAttribute
+    {
+        public string   overflow        = "Item {0}";
+        public string[] surfaceNames    = null;
+        public int      fixedSize       = 0;
+
+        public NamedItemsAttribute() { }
+        public NamedItemsAttribute(params string[] items)
+        {
+            surfaceNames = items; 
+        }
+    }
+}

--- a/Packages/com.chisel.core/Chisel/Core/PropertyDrawers/NamedItemsAttribute.cs.meta
+++ b/Packages/com.chisel.core/Chisel/Core/PropertyDrawers/NamedItemsAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aff1ff30a95f8584eab22fb7a3945610
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselFallbackNodeEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselFallbackNodeEditor.cs
@@ -13,7 +13,7 @@ namespace Chisel.Editors
 {
     [CustomEditor(typeof(ChiselNode), isFallback = true)]
     [CanEditMultipleObjects]
-    public sealed class ChiselFallbackNodeEditor : ChiselNodeEditor<ChiselModel>
+    public sealed class ChiselFallbackNodeEditor : ChiselNodeEditor<ChiselNode>
     {
     }
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeDetailsManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeDetailsManager.cs
@@ -14,6 +14,7 @@ namespace Chisel.Editors
     public static class ChiselNodeDetailsManager
     {
         static Dictionary<Type, IChiselNodeDetails> nodeDetailsLookup = new Dictionary<Type, IChiselNodeDetails>();
+        static IChiselNodeDetails generatorDefaultDetails = new ChiselDefaultGeneratorDetails();
 
         [InitializeOnLoadMethod]
         static void InitializeNodeDetails()
@@ -34,27 +35,24 @@ namespace Chisel.Editors
 
         public static IChiselNodeDetails GetNodeDetails(ChiselNode node)
         {
-            IChiselNodeDetails someInterface;
-            if (nodeDetailsLookup.TryGetValue(node.GetType(), out someInterface))
+            if (nodeDetailsLookup.TryGetValue(node.GetType(), out IChiselNodeDetails someInterface))
                 return someInterface;
-            return null;
+            return generatorDefaultDetails;
         }
 
         public static IChiselNodeDetails GetNodeDetails(Type type)
         {
-            IChiselNodeDetails someInterface;
-            if (nodeDetailsLookup.TryGetValue(type, out someInterface))
+            if (nodeDetailsLookup.TryGetValue(type, out IChiselNodeDetails someInterface))
                 return someInterface;
-            return null;
+            return generatorDefaultDetails;
         }
 
 
         public static GUIContent GetHierarchyIcon(ChiselNode node)
         {
-            IChiselNodeDetails someInterface;
-            if (nodeDetailsLookup.TryGetValue(node.GetType(), out someInterface))
+            if (nodeDetailsLookup.TryGetValue(node.GetType(), out IChiselNodeDetails someInterface))
                 return someInterface.GetHierarchyIconForGenericNode(node);
-            return null;
+            return generatorDefaultDetails.GetHierarchyIconForGenericNode(node);
         }
     }
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeEditor.cs
@@ -71,7 +71,11 @@ namespace Chisel.Editors
         // we can only do this from place where we specifically know which component the menu is for.
         protected static void CreateAsGameObjectMenuCommand(MenuCommand menuCommand, string name)
         {
-            var component   = ChiselComponentFactory.Create<T>(name, ChiselModelManager.GetActiveModelOrCreate());
+            T component;
+            if (typeof(T) == typeof(ChiselModel))
+                component   = ChiselComponentFactory.Create<T>(name);
+            else
+                component   = ChiselComponentFactory.Create<T>(name, ChiselModelManager.GetActiveModelOrCreate());
             var gameObject  = component.gameObject;
             GameObjectUtility.SetParentAndAlign(gameObject, menuCommand.context as GameObject);
             Undo.RegisterCreatedObjectUndo(gameObject, "Create " + gameObject.name);

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor;
 
 using System;
@@ -27,6 +27,23 @@ namespace Chisel.Editors
     {
         [MenuItem("GameObject/Chisel/" + ChiselModel.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselModel.kNodeTypeName); }
+
+
+        [ContextMenu("Set Active Model", false)]
+        static void SetActiveModel(MenuCommand menuCommand)
+        {
+            var model = (menuCommand.context as GameObject).GetComponent<ChiselModel>();
+            if (model)
+                ChiselModelManager.ActiveModel = model;
+        }
+
+        [ContextMenu("Set Active Model", true)]
+        static bool ValidateActiveModel(MenuCommand menuCommand)
+        {
+            var model = (menuCommand.context as GameObject).GetComponent<ChiselModel>();
+            return model;
+        }
+
 
         const int kSingleLineHeight = 16;
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 
 using System;
@@ -25,7 +25,7 @@ namespace Chisel.Editors
     [CanEditMultipleObjects]
     public sealed class ChiselModelEditor : ChiselNodeEditor<ChiselModel>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselModel.kNodeTypeName, false, -1)]
+        [MenuItem("GameObject/Chisel/" + ChiselModel.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselModel.kNodeTypeName); }
 
         const int kSingleLineHeight = 16;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselBoxEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselBoxEditor.cs
@@ -13,55 +13,13 @@ using UnityEditor.UIElements;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselBoxDetails : ChiselGeneratorDetails<ChiselBox>
-    {
-    }
-
     // TODO: why did resetting this generator not work?
     [CustomEditor(typeof(ChiselBox))]
     [CanEditMultipleObjects]
     public sealed class ChiselBoxEditor : ChiselGeneratorEditor<ChiselBox>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselBox.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselBox.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselBox.kNodeTypeName); }
-
-        static readonly GUIContent[] kSurfaceNameContent = new []
-        {
-            new GUIContent("Top"),
-            new GUIContent("Bottom"),
-            new GUIContent("Right"),
-            new GUIContent("Left"),
-            new GUIContent("Front"),
-            new GUIContent("Back")
-        };
-        
-        SerializedProperty boundsProp;
-        SerializedProperty surfacesProp;
-        
-        protected override void ResetInspector()
-        { 
-            boundsProp	    = null;
-            surfacesProp    = null;
-        }
-        
-        protected override void InitInspector()
-        { 
-            var definitionProp      = serializedObject.FindProperty(nameof(ChiselBox.definition));
-            { 
-                boundsProp	        = definitionProp.FindPropertyRelative(nameof(ChiselBox.definition.bounds));
-                var surfDefProp     = definitionProp.FindPropertyRelative(nameof(ChiselBox.definition.surfaceDefinition));
-                {
-                    surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselBox.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        protected override void OnInspector()
-        {
-            EditorGUILayout.PropertyField(boundsProp);
-
-            ShowSurfaces(surfacesProp, kSurfaceNameContent, 6);
-        }
 
         protected override void OnScene(SceneView sceneView, ChiselBox generator)
         {

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselBrushEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselBrushEditor.cs
@@ -11,38 +11,10 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselBrushDetails : ChiselGeneratorDetails<ChiselBrush>
-    {
-    }
-
     [CustomEditor(typeof(ChiselBrush))]
     [CanEditMultipleObjects]
     public sealed class ChiselBrushEditor : ChiselGeneratorEditor<ChiselBrush>
     {
-        SerializedProperty brushContainerAssetProp;
-
-        protected override void ResetInspector()
-        {
-            brushContainerAssetProp = null;
-        }
-
-        protected override void InitInspector()
-        {
-            brushContainerAssetProp = serializedObject.FindProperty(ChiselGeneratorComponent.kBrushContainerAssetName);
-        }
-        
-        protected override void OnInspector()
-        {
-            EditorGUI.BeginChangeCheck();
-            {
-                EditorGUILayout.PropertyField(brushContainerAssetProp);
-            }
-            if (EditorGUI.EndChangeCheck())
-            {
-                serializedObject.ApplyModifiedProperties();
-            }
-        }
-
         static Dictionary<ChiselBrush, ChiselEditableOutline> activeOutlines = new Dictionary<ChiselBrush, ChiselEditableOutline>();
 
         protected override void OnUndoRedoPerformed()

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCapsuleEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCapsuleEditor.cs
@@ -5,96 +5,12 @@ using UnityEngine;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselCapsuleDetails : ChiselGeneratorDetails<ChiselCapsule>
-    {
-    }
-
-
     [CustomEditor(typeof(ChiselCapsule))]
     [CanEditMultipleObjects]
     public sealed class ChiselCapsuleEditor : ChiselGeneratorEditor<ChiselCapsule>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselCapsule.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselCapsule.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselCapsule.kNodeTypeName); }
-
-        // TODO: make these shared resources since this name is used in several places (with identical context)
-        static readonly GUIContent  kSurfacesContent        = new GUIContent("Surfaces");
-        const string                kSurfacePropertyName    = "Side {0}";
-        const string                kSurfacePathName        = "{0}[{1}]";
-        static GUIContent           surfacePropertyContent  = new GUIContent();
-
-        SerializedProperty heightProp;
-        SerializedProperty topHeightProp;
-        SerializedProperty bottomHeightProp;
-
-        SerializedProperty diameterXProp;
-        SerializedProperty diameterZProp;
-        SerializedProperty rotationProp;
-
-        SerializedProperty sidesProp;
-        SerializedProperty topSegmentsProp;
-        SerializedProperty bottomSegmentsProp;
-
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        { 
-            heightProp			= null;
-            topHeightProp		= null;
-            bottomHeightProp	= null;
-
-            diameterXProp		= null;
-            diameterZProp		= null;
-            rotationProp		= null;
-
-            sidesProp			= null;
-            topSegmentsProp		= null;
-            bottomSegmentsProp	= null;
-
-            surfacesProp        = null;
-        }
-        
-        protected override void InitInspector()
-        {
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselCapsule.definition));
-            {
-                heightProp			= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.height));
-                topHeightProp		= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.topHeight));
-                bottomHeightProp	= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.bottomHeight));
-
-                diameterXProp		= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.diameterX));
-                diameterZProp		= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.diameterZ));
-                rotationProp		= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.rotation));
-
-                sidesProp			= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.sides));
-                topSegmentsProp		= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.topSegments));
-                bottomSegmentsProp	= definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.bottomSegments));
-                
-                var surfDefProp     = definitionProp.FindPropertyRelative(nameof(ChiselCapsule.definition.surfaceDefinition));
-                {
-                    surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselCapsule.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(heightProp);
-            EditorGUILayout.PropertyField(topHeightProp);
-            EditorGUILayout.PropertyField(bottomHeightProp);
-
-            EditorGUILayout.PropertyField(diameterXProp);
-            EditorGUILayout.PropertyField(diameterZProp);
-            EditorGUILayout.PropertyField(rotationProp);
-
-            EditorGUILayout.PropertyField(sidesProp);
-            EditorGUILayout.PropertyField(topSegmentsProp);
-            EditorGUILayout.PropertyField(bottomSegmentsProp);
-
-
-            ShowSurfaces(surfacesProp, surfacesProp.arraySize);
-        }
 
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCylinderEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCylinderEditor.cs
@@ -11,127 +11,14 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselCylinderDetails : ChiselGeneratorDetails<ChiselCylinder>
-    {
-    }
-    
     // TODO: why did resetting this generator not work?
     // TODO: make drag & drop of materials on generator side work
     [CustomEditor(typeof(ChiselCylinder))]
     [CanEditMultipleObjects]
     public sealed class ChiselCylinderEditor : ChiselGeneratorEditor<ChiselCylinder>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselCylinder.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselCylinder.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselCylinder.kNodeTypeName); }
-
-        GUIContent[] kSurfaceNameContent = new[]
-        {
-            new GUIContent("Top"),
-            new GUIContent("Bottom")
-        };
-
-        SerializedProperty typeProp;
-        SerializedProperty topHeightProp;
-        SerializedProperty topDiameterXProp;
-        SerializedProperty topDiameterZProp;
-        SerializedProperty bottomHeightProp;
-        SerializedProperty bottomDiameterXProp;
-        SerializedProperty bottomDiameterZProp;
-        SerializedProperty rotationProp;
-        SerializedProperty isEllipsoidProp;
-        SerializedProperty smoothingGroupProp;
-        SerializedProperty sidesProp;
-        SerializedProperty surfacesProp;
-        
-        protected override void ResetInspector()
-        { 
-            typeProp				= null;
-            topHeightProp			= null;
-            topDiameterXProp		= null;
-            topDiameterZProp		= null;
-            bottomHeightProp		= null;
-            bottomDiameterXProp		= null;
-            bottomDiameterZProp		= null;
-            isEllipsoidProp			= null;
-            smoothingGroupProp		= null;
-            sidesProp				= null;
-
-            surfacesProp            = null;
-        }
-        
-        protected override void InitInspector()
-        { 
-            var definitionProp      = serializedObject.FindProperty(nameof(ChiselCylinder.definition));
-            { 
-                typeProp			    = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.type));
-
-                var topProp             = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.top));
-                { 
-                    topHeightProp	    = topProp.FindPropertyRelative(nameof(ChiselCylinder.definition.top.height));
-                    topDiameterXProp    = topProp.FindPropertyRelative(nameof(ChiselCylinder.definition.top.diameterX));
-                    topDiameterZProp    = topProp.FindPropertyRelative(nameof(ChiselCylinder.definition.top.diameterZ));
-                }
-            
-                var bottomProp          = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.bottom));
-                { 
-                    bottomHeightProp    = bottomProp.FindPropertyRelative(nameof(ChiselCylinder.definition.bottom.height));
-                    bottomDiameterXProp = bottomProp.FindPropertyRelative(nameof(ChiselCylinder.definition.bottom.diameterX));
-                    bottomDiameterZProp = bottomProp.FindPropertyRelative(nameof(ChiselCylinder.definition.bottom.diameterZ));
-                }
-
-                rotationProp		    = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.rotation));
-                isEllipsoidProp		    = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.isEllipsoid));
-                smoothingGroupProp	    = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.smoothingGroup));
-                sidesProp			    = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.sides));
-                
-                var surfDefProp         = definitionProp.FindPropertyRelative(nameof(ChiselCylinder.definition.surfaceDefinition));
-                {
-                    surfacesProp        = surfDefProp.FindPropertyRelative(nameof(ChiselCylinder.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(typeProp);
-            EditorGUILayout.PropertyField(isEllipsoidProp);
-            
-            EditorGUILayout.Space();
-
-            EditorGUILayout.LabelField("Top");
-            EditorGUI.indentLevel++;
-            {
-                EditorGUILayout.PropertyField(topHeightProp);
-                if ((CylinderShapeType)typeProp.enumValueIndex == CylinderShapeType.ConicalFrustum)
-                {
-                    EditorGUILayout.PropertyField(topDiameterXProp);
-                    if (isEllipsoidProp.boolValue)
-                        EditorGUILayout.PropertyField(topDiameterZProp);
-                }
-            }
-            EditorGUI.indentLevel--;
-
-            EditorGUILayout.LabelField("Bottom");
-            EditorGUI.indentLevel++;
-            {
-                EditorGUILayout.PropertyField(bottomHeightProp);
-                EditorGUILayout.PropertyField(bottomDiameterXProp);
-                if (isEllipsoidProp.boolValue)
-                    EditorGUILayout.PropertyField(bottomDiameterZProp);
-            }
-            EditorGUI.indentLevel--;
-
-            EditorGUILayout.Space();
-            {
-                EditorGUILayout.PropertyField(sidesProp);
-                EditorGUILayout.PropertyField(smoothingGroupProp);
-                EditorGUILayout.PropertyField(rotationProp);
-            }
-            EditorGUILayout.Space();
-
-
-            ShowSurfaces(surfacesProp, kSurfaceNameContent);
-        }
         
         // TODO: put somewhere else
         public static Color GetColorForState(Color baseColor, bool hasFocus, bool isBackfaced, bool isDisabled)

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselExtrudedShapeEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselExtrudedShapeEditor.cs
@@ -11,56 +11,12 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselExtrudedShapeDetails : ChiselGeneratorDetails<ChiselExtrudedShape>
-    {
-    }
-    
     [CustomEditor(typeof(ChiselExtrudedShape))]
     [CanEditMultipleObjects]
     public sealed class ChiselExtrudedShapeEditor : ChiselGeneratorEditor<ChiselExtrudedShape>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselExtrudedShape.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselExtrudedShape.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselExtrudedShape.kNodeTypeName); }
-
-        static readonly GUIContent  kShapeContent   = new GUIContent("Shape");
-        static readonly GUIContent  kPathContent    = new GUIContent("Path");
-
-        SerializedProperty controlPointsProp;
-        SerializedProperty pathSegmentsProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        {
-            controlPointsProp   = null;
-            pathSegmentsProp    = null;
-
-            surfacesProp        = null;
-        }
-        
-        protected override void InitInspector()
-        {
-            var definitionProp  = serializedObject.FindProperty(nameof(ChiselExtrudedShape.definition));
-            {
-                var shapeProp		= definitionProp.FindPropertyRelative(nameof(ChiselExtrudedShape.definition.shape));
-                controlPointsProp   = shapeProp.FindPropertyRelative(nameof(ChiselExtrudedShape.definition.shape.controlPoints));
-
-                var pathProp		= definitionProp.FindPropertyRelative(nameof(ChiselExtrudedShape.definition.path));
-                pathSegmentsProp	= pathProp.FindPropertyRelative(nameof(ChiselExtrudedShape.definition.path.segments));
-
-                var surfDefProp     = definitionProp.FindPropertyRelative(nameof(ChiselExtrudedShape.definition.surfaceDefinition));
-                {
-                    surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselExtrudedShape.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(controlPointsProp, kShapeContent, true);
-            EditorGUILayout.PropertyField(pathSegmentsProp,  kPathContent,  true);
-
-            ShowSurfaces(surfacesProp);
-        }
 
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselHemisphereEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselHemisphereEditor.cs
@@ -11,61 +11,12 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselHemisphereDetails : ChiselGeneratorDetails<ChiselHemisphere>
-    {
-    }
-
-
     [CustomEditor(typeof(ChiselHemisphere))]
     [CanEditMultipleObjects]
     public sealed class ChiselHemisphereEditor : ChiselGeneratorEditor<ChiselHemisphere>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselHemisphere.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselHemisphere.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselHemisphere.kNodeTypeName); }
-
-
-        SerializedProperty diameterXYZProp;
-        SerializedProperty rotationProp;
-        SerializedProperty horizontalSegmentsProp;
-        SerializedProperty verticalSegmentsProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        { 
-            diameterXYZProp			= null;
-            rotationProp			= null;
-            horizontalSegmentsProp	= null;
-            verticalSegmentsProp	= null;
-
-            surfacesProp            = null;
-        }
-        
-        protected override void InitInspector()
-        {
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselHemisphere.definition));
-            {
-                diameterXYZProp			= definitionProp.FindPropertyRelative(nameof(ChiselHemisphere.definition.diameterXYZ));
-                rotationProp			= definitionProp.FindPropertyRelative(nameof(ChiselHemisphere.definition.rotation));
-                horizontalSegmentsProp	= definitionProp.FindPropertyRelative(nameof(ChiselHemisphere.definition.horizontalSegments));
-                verticalSegmentsProp	= definitionProp.FindPropertyRelative(nameof(ChiselHemisphere.definition.verticalSegments));
-
-                var surfDefProp         = definitionProp.FindPropertyRelative(nameof(ChiselHemisphere.definition.surfaceDefinition));
-                {
-                    surfacesProp        = surfDefProp.FindPropertyRelative(nameof(ChiselHemisphere.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(diameterXYZProp);
-            EditorGUILayout.PropertyField(rotationProp);
-            EditorGUILayout.PropertyField(horizontalSegmentsProp);
-            EditorGUILayout.PropertyField(verticalSegmentsProp);
-
-            ShowSurfaces(surfacesProp);
-        }
 
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselLinearStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselLinearStairsEditor.cs
@@ -11,126 +11,19 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselLinearStairsDetails : ChiselGeneratorDetails<ChiselLinearStairs>
-    {
-    }
-    
     [CustomEditor(typeof(ChiselLinearStairs))]
     [CanEditMultipleObjects]
     public sealed class ChiselLinearStairsEditor : ChiselGeneratorEditor<ChiselLinearStairs>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselLinearStairs.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselLinearStairs.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselLinearStairs.kNodeTypeName); }
 
-        #region Inspector
-        static readonly GUIContent[] kSurfaceContentNames = new[]
-        {
-            new GUIContent("Top"),
-            new GUIContent("Bottom"),
-            new GUIContent("Right"),
-            new GUIContent("Left"),
-            new GUIContent("Front"),
-            new GUIContent("Back"),
-            new GUIContent("Tread"),
-            new GUIContent("Step")
-        };
-
-        SerializedProperty boundsProp;
-        SerializedProperty stepHeightProp;
-        SerializedProperty stepDepthProp;
-        SerializedProperty riserTypeProp;
-        SerializedProperty riserDepthProp;
-        SerializedProperty treadHeightProp;
-        SerializedProperty nosingDepthProp;
-        SerializedProperty nosingWidthProp;
-        SerializedProperty plateauHeightProp;
-        SerializedProperty leftSideProp;
-        SerializedProperty rightSideProp;
-        SerializedProperty sideDepthProp;
-        SerializedProperty sideWidthProp;
-        SerializedProperty sideHeightProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        {
-            boundsProp			= null;
-            stepHeightProp		= null;
-            stepDepthProp		= null;
-            plateauHeightProp	= null;
-            riserTypeProp		= null;
-            leftSideProp		= null;
-            rightSideProp		= null;
-            riserDepthProp		= null;
-            sideDepthProp		= null;
-            sideWidthProp		= null;
-            sideHeightProp		= null;
-            treadHeightProp		= null;
-            nosingDepthProp		= null;
-            nosingWidthProp		= null;
-
-            surfacesProp        = null;
-        }
-
-        protected override void InitInspector()
-        {
-            EditorGUI.BeginChangeCheck();
-            {
-                var definitionProp = serializedObject.FindProperty(nameof(ChiselLinearStairs.definition));
-                {
-                    boundsProp		    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.bounds));
-                    stepHeightProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.stepHeight));
-                    stepDepthProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.stepDepth));
-                    plateauHeightProp	= definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.plateauHeight));
-                    riserTypeProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.riserType));
-                    riserDepthProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.riserDepth));
-                    leftSideProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.leftSide));
-                    rightSideProp		= definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.rightSide));
-                    sideDepthProp		= definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.sideDepth));
-                    sideWidthProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.sideWidth));
-                    sideHeightProp	    = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.sideHeight));
-                    treadHeightProp		= definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.treadHeight));
-                    nosingDepthProp		= definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.nosingDepth));
-                    nosingWidthProp		= definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.nosingWidth));
-
-                    var surfDefProp     = definitionProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.surfaceDefinition));
-                    {
-                        surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselLinearStairs.definition.surfaceDefinition.surfaces));
-                    }
-                }
-            }
-            if (EditorGUI.EndChangeCheck())
-            {
-                generatorModified = true;
-                UpdateDefinitions();
-            }
-        }
-        
-        protected override void OnInspector()
-        {
-            EditorGUILayout.PropertyField(boundsProp);
-            EditorGUILayout.PropertyField(stepHeightProp);
-            EditorGUILayout.PropertyField(stepDepthProp);
-            EditorGUILayout.PropertyField(treadHeightProp);
-            EditorGUILayout.PropertyField(nosingDepthProp);
-            EditorGUILayout.PropertyField(nosingWidthProp);
-            EditorGUILayout.PropertyField(plateauHeightProp);
-            EditorGUILayout.PropertyField(riserTypeProp);
-            EditorGUILayout.PropertyField(riserDepthProp);
-            EditorGUILayout.PropertyField(leftSideProp);
-            EditorGUILayout.PropertyField(rightSideProp);
-            EditorGUILayout.PropertyField(sideWidthProp);
-            EditorGUILayout.PropertyField(sideHeightProp);
-            EditorGUILayout.PropertyField(sideDepthProp);
-
-
-            ShowSurfaces(surfacesProp, kSurfaceContentNames, kSurfaceContentNames.Length);
-        }
-        #endregion
 
         #region Selection
         static Dictionary<ChiselLinearStairs, ChiselLinearStairsDefinition> activeGeneratorDefinitions = new Dictionary<ChiselLinearStairs, ChiselLinearStairsDefinition>();
 
         protected override void OnUndoRedoPerformed() { UpdateDefinitions(); }
+        protected override void OnTargetModifiedInInspector() { generatorModified = true; UpdateDefinitions(); }
 
         protected override void OnGeneratorSelected(ChiselLinearStairs generator)
         {
@@ -179,6 +72,7 @@ namespace Chisel.Editors
 
         // TODO: put somewhere else
         public static Color iconColor = new Color(201f / 255, 200f / 255, 144f / 255, 1.00f);
+
 
         static bool ShowGeneratorHandles(ChiselLinearStairs generator, ChiselLinearStairsDefinition cachedDefinition)
         {

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselPathedStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselPathedStairsEditor.cs
@@ -11,131 +11,13 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselPathedStairsDetails : ChiselGeneratorDetails<ChiselPathedStairs>
-    {
-    }
-
     [CustomEditor(typeof(ChiselPathedStairs))]
     [CanEditMultipleObjects]
     public sealed class ChiselPathedStairsEditor : ChiselGeneratorEditor<ChiselPathedStairs>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselPathedStairs.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselPathedStairs.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselPathedStairs.kNodeTypeName); }
 
-        static readonly GUIContent[] kSurfaceContentNames = new[]
-        {
-            new GUIContent("Top"),
-            new GUIContent("Bottom"),
-            new GUIContent("Right"),
-            new GUIContent("Left"),
-            new GUIContent("Front"),
-            new GUIContent("Back"),
-            new GUIContent("Tread"),
-            new GUIContent("Step")
-        };
-
-        static GUIContent   shapeContent	= new GUIContent("Shape");
-        
-        SerializedProperty shapeProp;
-        SerializedProperty closedProp;
-        SerializedProperty curveSegments;
-
-        SerializedProperty boundsProp;
-        SerializedProperty stepHeightProp;
-        SerializedProperty stepDepthProp;
-        SerializedProperty riserTypeProp;
-        SerializedProperty riserDepthProp;
-        SerializedProperty treadHeightProp;
-        SerializedProperty nosingDepthProp;
-        SerializedProperty nosingWidthProp;
-        SerializedProperty plateauHeightProp;
-        SerializedProperty leftSideProp;
-        SerializedProperty rightSideProp;
-        SerializedProperty sideDepthProp;
-        SerializedProperty sideWidthProp;
-        SerializedProperty sideHeightProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        {
-            shapeProp			= null;
-            closedProp			= null;
-            curveSegments		= null;
-
-            boundsProp			= null;
-            stepHeightProp		= null;
-            stepDepthProp		= null;
-            plateauHeightProp	= null;
-            riserTypeProp		= null;
-            leftSideProp		= null;
-            rightSideProp		= null;
-            riserDepthProp		= null;
-            sideDepthProp		= null;
-            sideWidthProp		= null;
-            sideHeightProp		= null;
-            treadHeightProp		= null;
-            nosingDepthProp		= null;
-            nosingWidthProp		= null;
-
-            surfacesProp = null;
-        }
-
-        protected override void InitInspector()
-        {
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselPathedStairs.definition));
-            {
-                shapeProp			= definitionProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.shape.controlPoints));
-                closedProp			= definitionProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.shape.closed));
-                curveSegments		= definitionProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.curveSegments));
-
-                var stairsProp      = serializedObject.FindProperty(nameof(ChiselPathedStairs.definition.stairs));
-                {
-                    boundsProp			= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.bounds));
-                    stepHeightProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.stepHeight));
-                    stepDepthProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.stepDepth));
-                    plateauHeightProp	= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.plateauHeight));
-                    riserTypeProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.riserType));
-                    riserDepthProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.riserDepth));
-                    leftSideProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.leftSide));
-                    rightSideProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.rightSide));
-                    sideDepthProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.sideDepth));
-                    sideWidthProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.sideWidth));
-                    sideHeightProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.sideHeight));
-                    treadHeightProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.treadHeight));
-                    nosingDepthProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.nosingDepth));
-                    nosingWidthProp		= stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.nosingWidth));
-
-                    var surfDefProp     = stairsProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.surfaceDefinition));
-                    {
-                        surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselPathedStairs.definition.stairs.surfaceDefinition.surfaces));
-                    }
-                }
-            }
-        }
-
-        protected override void OnInspector()
-        {
-            EditorGUILayout.PropertyField(shapeProp, shapeContent, true);
-            EditorGUILayout.PropertyField(closedProp);
-            EditorGUILayout.PropertyField(curveSegments);
-
-            EditorGUILayout.PropertyField(boundsProp);
-            EditorGUILayout.PropertyField(stepHeightProp);
-            EditorGUILayout.PropertyField(stepDepthProp);
-            EditorGUILayout.PropertyField(treadHeightProp);
-            EditorGUILayout.PropertyField(nosingDepthProp);
-            EditorGUILayout.PropertyField(nosingWidthProp);
-            EditorGUILayout.PropertyField(plateauHeightProp);
-            EditorGUILayout.PropertyField(riserTypeProp);
-            EditorGUILayout.PropertyField(riserDepthProp);
-            EditorGUILayout.PropertyField(leftSideProp);
-            EditorGUILayout.PropertyField(rightSideProp);
-            EditorGUILayout.PropertyField(sideWidthProp);
-            EditorGUILayout.PropertyField(sideHeightProp);
-            EditorGUILayout.PropertyField(sideDepthProp);
-
-            ShowSurfaces(surfacesProp, kSurfaceContentNames, kSurfaceContentNames.Length);
-        }
 
         public static bool Intersect(Vector2 p1, Vector2 d1, 
                                      Vector2 p2, Vector2 d2, out Vector2 intersection)

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselRevolvedShapeEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselRevolvedShapeEditor.cs
@@ -11,73 +11,13 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselRevolvedShapeDetails : ChiselGeneratorDetails<ChiselRevolvedShape>
-    {
-    }
-
     [CustomEditor(typeof(ChiselRevolvedShape))]
     [CanEditMultipleObjects]
     public sealed class ChiselRevolvedShapeEditor : ChiselGeneratorEditor<ChiselRevolvedShape>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselRevolvedShape.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselRevolvedShape.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselRevolvedShape.kNodeTypeName); }
 
-        // TODO: make these shared resources since this name is used in several places (with identical context)
-        static readonly GUIContent  kSurfacesContent        = new GUIContent("Surfaces");
-        const string                kSurfacePropertyName    = "Side {0}";
-        static GUIContent           surfacePropertyContent  = new GUIContent();
-        static readonly GUIContent  kShapeContent	        = new GUIContent("Shape");
-
-        SerializedProperty shapeProp;
-        SerializedProperty curveSegments;
-        SerializedProperty revolveSegments;
-        SerializedProperty startAngleProp;
-        SerializedProperty totalAngleProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        {
-            shapeProp		= null;
-            curveSegments	= null;
-            revolveSegments	= null;
-            startAngleProp	= null;
-            totalAngleProp	= null;
-
-            surfacesProp    = null;
-        }
-
-        protected override void InitInspector()
-        {
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselRevolvedShape.definition));
-            {
-                curveSegments       = definitionProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.curveSegments));
-                revolveSegments     = definitionProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.revolveSegments));
-                startAngleProp      = definitionProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.startAngle));
-                totalAngleProp      = definitionProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.totalAngle));
-                shapeProp	        = definitionProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.shape.controlPoints));
-
-                var surfDefProp     = definitionProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.surfaceDefinition));
-                {
-                    surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselRevolvedShape.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        protected override void OnInspector()
-        {
-            EditorGUILayout.PropertyField(shapeProp, kShapeContent, true);
-            EditorGUILayout.PropertyField(curveSegments);
-            EditorGUILayout.PropertyField(revolveSegments);
-
-            EditorGUILayout.PropertyField(startAngleProp);
-            EditorGUILayout.PropertyField(totalAngleProp);
-
-
-            ShowSurfaces(surfacesProp);
-        }
-
-
-        
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;
         const float kHorzLineThickness			= 1.0f;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSphereEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSphereEditor.cs
@@ -11,59 +11,13 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselSphereDetails : ChiselGeneratorDetails<ChiselSphere>
-    {
-    }
-
     [CustomEditor(typeof(ChiselSphere))]
     [CanEditMultipleObjects]
     public sealed class ChiselSphereEditor : ChiselGeneratorEditor<ChiselSphere>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselSphere.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselSphere.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselSphere.kNodeTypeName); }
 
-        SerializedProperty diameterXYZProp;
-        SerializedProperty rotationProp;
-        SerializedProperty horizontalSegmentsProp;
-        SerializedProperty verticalSegmentsProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        { 
-            diameterXYZProp		    = null;
-            rotationProp		    = null;
-            horizontalSegmentsProp  = null;
-            verticalSegmentsProp    = null;
-            surfacesProp            = null;
-        }
-        
-        protected override void InitInspector()
-        { 
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselSphere.definition));
-            {
-                diameterXYZProp		    = definitionProp.FindPropertyRelative(nameof(ChiselSphere.definition.diameterXYZ));
-                rotationProp		    = definitionProp.FindPropertyRelative(nameof(ChiselSphere.definition.rotation));
-                horizontalSegmentsProp  = definitionProp.FindPropertyRelative(nameof(ChiselSphere.definition.horizontalSegments));
-                verticalSegmentsProp    = definitionProp.FindPropertyRelative(nameof(ChiselSphere.definition.verticalSegments));
-
-                var surfDefProp         = definitionProp.FindPropertyRelative(nameof(ChiselSphere.definition.surfaceDefinition));
-                {
-                    surfacesProp        = surfDefProp.FindPropertyRelative(nameof(ChiselSphere.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(diameterXYZProp);
-            EditorGUILayout.PropertyField(rotationProp);
-            EditorGUILayout.PropertyField(horizontalSegmentsProp);
-            EditorGUILayout.PropertyField(verticalSegmentsProp);
-
-            ShowSurfaces(surfacesProp);
-        }
-        
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;
         const float kHorzLineThickness			= 1.0f;
@@ -72,9 +26,6 @@ namespace Chisel.Editors
 
         static void DrawOutline(ChiselSphereDefinition definition, Vector3[] vertices, LineMode lineMode)
         {
-            //var baseColor		= UnityEditor.Handles.yAxisColor;
-            //var isDisabled		= UnitySceneExtensions.Handles.disabled;
-            //var normal			= Vector3.up;
             var sides			= definition.horizontalSegments;
             
             var extraVertices	= 2;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
@@ -11,111 +11,13 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselSpiralStairsDetails : ChiselGeneratorDetails<ChiselSpiralStairs>
-    {
-    }
-
     [CustomEditor(typeof(ChiselSpiralStairs))]
     [CanEditMultipleObjects]
     public sealed class ChiselSpiralStairsEditor : ChiselGeneratorEditor<ChiselSpiralStairs>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselSpiralStairs.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselSpiralStairs.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselSpiralStairs.kNodeTypeName); }
 
-        static readonly GUIContent[] kSurfaceContentNames = new[]
-        {
-            new GUIContent("Tread Top"),
-            new GUIContent("Tread Bottom"),
-            new GUIContent("Tread Front"),
-            new GUIContent("Tread Back"),
-            new GUIContent("Riser Front"),
-            new GUIContent("Riser Back"),
-            new GUIContent("Inner"),
-            new GUIContent("Outer"),
-        };
-
-        SerializedProperty heightProp;
-        SerializedProperty outerDiameterProp;
-        SerializedProperty outerSegmentsProp;
-        SerializedProperty innerDiameterProp;
-        SerializedProperty innerSegmentsProp;
-        SerializedProperty stepHeightProp;
-        SerializedProperty nosingDepthProp;
-        SerializedProperty nosingWidthProp;
-        SerializedProperty treadHeightProp;
-        SerializedProperty startAngleProp;
-        SerializedProperty rotationProp;
-        SerializedProperty riserTypeProp;
-        SerializedProperty riserDepthProp;
-        SerializedProperty bottomSmoothingGroupProp;
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        {
-            heightProp					= null;
-            outerDiameterProp			= null;
-            outerSegmentsProp			= null;
-            innerDiameterProp			= null;
-            innerSegmentsProp			= null;
-            stepHeightProp				= null;
-            nosingDepthProp				= null;
-            nosingWidthProp				= null;
-            treadHeightProp				= null;
-            startAngleProp				= null;
-            rotationProp				= null;
-            riserTypeProp				= null;
-            riserDepthProp				= null;
-            bottomSmoothingGroupProp	= null;
-
-            surfacesProp                = null;
-        }
-        
-        protected override void InitInspector()
-        {
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselSpiralStairs.definition));
-            {
-                heightProp					= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.height));
-                outerDiameterProp			= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.outerDiameter));
-                outerSegmentsProp			= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.outerSegments));
-                innerDiameterProp			= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.innerDiameter));
-                innerSegmentsProp			= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.innerSegments));
-                stepHeightProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.stepHeight));
-                treadHeightProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.treadHeight));
-                nosingDepthProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.nosingDepth));
-                nosingWidthProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.nosingWidth));
-                startAngleProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.startAngle));
-                rotationProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.rotation));
-                riserTypeProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.riserType));
-                riserDepthProp				= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.riserDepth));
-                bottomSmoothingGroupProp	= definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.bottomSmoothingGroup));
-
-                var surfDefProp             = definitionProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.surfaceDefinition));
-                {
-                    surfacesProp            = surfDefProp.FindPropertyRelative(nameof(ChiselSpiralStairs.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(heightProp);
-            EditorGUILayout.PropertyField(outerDiameterProp);
-            EditorGUILayout.PropertyField(outerSegmentsProp);
-            EditorGUILayout.PropertyField(innerDiameterProp);
-            EditorGUILayout.PropertyField(innerSegmentsProp);
-            EditorGUILayout.PropertyField(stepHeightProp);
-            EditorGUILayout.PropertyField(treadHeightProp);
-            EditorGUILayout.PropertyField(nosingDepthProp);
-            EditorGUILayout.PropertyField(nosingWidthProp);
-            EditorGUILayout.PropertyField(startAngleProp);
-            EditorGUILayout.PropertyField(rotationProp);
-            EditorGUILayout.PropertyField(riserTypeProp);
-            EditorGUILayout.PropertyField(riserDepthProp);
-            EditorGUILayout.PropertyField(bottomSmoothingGroupProp);
-
-            ShowSurfaces(surfacesProp, kSurfaceContentNames, kSurfaceContentNames.Length);
-        }
-        
                         
         // TODO: put somewhere else
 
@@ -228,7 +130,7 @@ namespace Chisel.Editors
                 var startRotateEdgeID	= GUIUtility.GetControlID ("SpiralStairsStartAngle".GetHashCode(), FocusType.Keyboard);
                 var endRotateEdgeID		= GUIUtility.GetControlID ("SpiralStairsEndAngle".GetHashCode(), FocusType.Keyboard);
                         
-                // TODO: properly show things as backfaces
+                // TODO: properly show things as backfaced
                 // TODO: temporarily show inner or outer diameter as disabled when resizing one or the other
                 // TODO: FIXME: why aren't there any arrows?
                 topPoint		= UnitySceneExtensions.SceneHandles.DirectionHandle(topPoint,  normal, snappingStep: originalStepHeight);

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselStadiumEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselStadiumEditor.cs
@@ -11,80 +11,12 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselStadiumDetails : ChiselGeneratorDetails<ChiselStadium>
-    {
-    }
-    
     [CustomEditor(typeof(ChiselStadium))]
     [CanEditMultipleObjects]
     public sealed class ChiselStadiumEditor : ChiselGeneratorEditor<ChiselStadium>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselStadium.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselStadium.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselStadium.kNodeTypeName); }
-
-        SerializedProperty heightProp;
-        SerializedProperty lengthProp;
-        SerializedProperty topLengthProp;
-        SerializedProperty bottomLengthProp;
-
-        SerializedProperty diameterProp;
-        
-        SerializedProperty topSidesProp;
-        SerializedProperty bottomSidesProp;
-
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        {
-            heightProp			= null;
-            lengthProp			= null;
-            topLengthProp		= null;
-            bottomLengthProp	= null;
-
-            diameterProp		= null;
-        
-            topSidesProp		= null;
-            bottomSidesProp		= null;
-
-            surfacesProp        = null;
-        }
-
-        protected override void InitInspector()
-        {
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselStadium.definition));
-            {
-                heightProp			= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.height));
-
-                lengthProp			= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.length));
-                topLengthProp		= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.topLength));
-                bottomLengthProp	= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.bottomLength));
-
-                diameterProp		= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.diameter));
-
-                topSidesProp		= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.topSides));
-                bottomSidesProp		= definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.bottomSides));
-
-                var surfDefProp     = definitionProp.FindPropertyRelative(nameof(ChiselStadium.definition.surfaceDefinition));
-                {
-                    surfacesProp    = surfDefProp.FindPropertyRelative(nameof(ChiselStadium.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        protected override void OnInspector()
-        {
-            EditorGUILayout.PropertyField(heightProp);
-            EditorGUILayout.PropertyField(lengthProp);
-            EditorGUILayout.PropertyField(topLengthProp);
-            EditorGUILayout.PropertyField(bottomLengthProp);
-
-            EditorGUILayout.PropertyField(diameterProp);
-        
-            EditorGUILayout.PropertyField(topSidesProp);
-            EditorGUILayout.PropertyField(bottomSidesProp);
-            
-            ShowSurfaces(surfacesProp);
-        }
 
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselTorusEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselTorusEditor.cs
@@ -11,105 +11,12 @@ using UnitySceneExtensions;
 
 namespace Chisel.Editors
 {
-    public sealed class ChiselTorusDetails : ChiselGeneratorDetails<ChiselTorus>
-    {
-    }
-
     [CustomEditor(typeof(ChiselTorus))]
     [CanEditMultipleObjects]
     public sealed class ChiselTorusEditor : ChiselGeneratorEditor<ChiselTorus>
     {
-        [MenuItem("GameObject/Chisel/" + ChiselTorus.kNodeTypeName)]
+        [MenuItem("GameObject/Chisel/" + ChiselTorus.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselTorus.kNodeTypeName); }
-
-        static readonly GUIContent  kInnerDiameterContent   = new GUIContent("Inner Diameter");
-
-        SerializedProperty outerDiameterProp;
-        SerializedProperty tubeWidthProp;
-        SerializedProperty tubeHeightProp;
-        SerializedProperty tubeRotationProp;
-        SerializedProperty horizontalSegmentsProp;
-        SerializedProperty verticalSegmentsProp;
-        SerializedProperty startAngleProp;
-        SerializedProperty totalAngleProp;
-        SerializedProperty fitCircleProp;
-
-        SerializedProperty surfacesProp;
-
-        protected override void ResetInspector()
-        { 
-            outerDiameterProp		= null;
-            tubeWidthProp			= null;
-            tubeHeightProp			= null;
-            tubeRotationProp		= null;
-            horizontalSegmentsProp	= null;
-            verticalSegmentsProp	= null;
-            startAngleProp			= null;
-            totalAngleProp			= null;
-            fitCircleProp			= null;
-
-            surfacesProp            = null;
-        }
-        
-        protected override void InitInspector()
-        { 
-            var definitionProp = serializedObject.FindProperty(nameof(ChiselTorus.definition));
-            {
-                outerDiameterProp		= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.outerDiameter));
-                tubeWidthProp			= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.tubeWidth));
-                tubeHeightProp			= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.tubeHeight));
-                tubeRotationProp		= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.tubeRotation));
-                horizontalSegmentsProp	= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.horizontalSegments));
-                verticalSegmentsProp	= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.verticalSegments));
-                startAngleProp			= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.startAngle));
-                totalAngleProp			= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.totalAngle));
-                fitCircleProp			= definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.fitCircle));
-
-                var surfDefProp         = definitionProp.FindPropertyRelative(nameof(ChiselTorus.definition.surfaceDefinition));
-                {
-                    surfacesProp        = surfDefProp.FindPropertyRelative(nameof(ChiselTorus.definition.surfaceDefinition.surfaces));
-                }
-            }
-        }
-
-        void InnerDiameterPropertyField()
-        {
-            var content		= kInnerDiameterContent;
-            var position	= GUILayoutUtility.GetRect(content, EditorStyles.numberField);
-            content = EditorGUI.BeginProperty(position, content, tubeWidthProp);
-            {
-                EditorGUI.showMixedValue = outerDiameterProp.hasMultipleDifferentValues || 
-                                           tubeWidthProp.hasMultipleDifferentValues;
-                float innerDiameter;
-                EditorGUI.BeginChangeCheck();
-                {
-                    innerDiameter = ChiselTorusDefinition.CalcInnerDiameter(outerDiameterProp.floatValue, tubeWidthProp.floatValue);
-                    innerDiameter = EditorGUI.FloatField(position, content, innerDiameter);
-                }
-                if (EditorGUI.EndChangeCheck())
-                    tubeWidthProp.floatValue = ChiselTorusDefinition.CalcTubeWidth(outerDiameterProp.floatValue, innerDiameter);
-            }
-            EditorGUI.EndProperty();
-        }
-
-        
-        protected override void OnInspector()
-        { 
-            EditorGUILayout.PropertyField(outerDiameterProp);
-            InnerDiameterPropertyField();
-            EditorGUILayout.PropertyField(tubeWidthProp);
-            EditorGUILayout.PropertyField(tubeHeightProp);
-            EditorGUILayout.PropertyField(fitCircleProp);
-            EditorGUILayout.PropertyField(tubeRotationProp);
-
-            EditorGUILayout.PropertyField(horizontalSegmentsProp);
-            EditorGUILayout.PropertyField(verticalSegmentsProp);
-
-            EditorGUILayout.PropertyField(startAngleProp);
-            EditorGUILayout.PropertyField(totalAngleProp);
-
-            ShowSurfaces(surfacesProp);
-        }
 
         const float kLineDash					= 2.0f;
         const float kVertLineThickness			= 0.75f;

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselPathedStairsGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselPathedStairsGeneratorMode.cs
@@ -10,18 +10,18 @@ using UnityEditor.ShortcutManagement;
 
 namespace Chisel.Editors
 {
+// Disabled, for the time being, because this generator has not been implemented yet
+#if false
     public sealed class ChiselPathedStairsGeneratorMode : ChiselGeneratorToolMode
     {
         const string kToolName = ChiselPathedStairs.kNodeTypeName;
         public override string ToolName => kToolName;
 
-        // Commented out, for the time being, because this generator has not been implemented yet
-        /*
         #region Keyboard Shortcut
         const string kToolShotcutName = ChiselKeyboardDefaults.ShortCutCreateBase + kToolName;
         [Shortcut(kToolShotcutName, ChiselKeyboardDefaults.PathedStairsBuilderModeKey, ChiselKeyboardDefaults.PathedStairsBuilderModeModifiers, displayName = kToolShotcutName)]
         public static void StartGeneratorMode() { ChiselEditModeManager.EditModeType = typeof(ChiselPathedStairsGeneratorMode); }
         #endregion
-        */
     }
+#endif
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselRevolvedShapeGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselRevolvedShapeGeneratorMode.cs
@@ -10,18 +10,18 @@ using UnityEditor.ShortcutManagement;
 
 namespace Chisel.Editors
 {
+// Disabled, for the time being, because this generator has not been implemented yet
+#if false
     public sealed class ChiselRevolvedShapeGeneratorMode : ChiselGeneratorToolMode
     {
         const string kToolName = ChiselRevolvedShape.kNodeTypeName;
         public override string ToolName => kToolName;
 
-        // Commented out, for the time being, because this generator has not been implemented yet
-        /*
         #region Keyboard Shortcut
         const string kToolShotcutName = ChiselKeyboardDefaults.ShortCutCreateBase + kToolName;
         [Shortcut(kToolShotcutName, ChiselKeyboardDefaults.RevolvedShapeBuilderModeKey, ChiselKeyboardDefaults.RevolvedShapeBuilderModeModifiers, displayName = kToolShotcutName)]
         public static void StartGeneratorMode() { ChiselEditModeManager.EditModeType = typeof(ChiselRevolvedShapeGeneratorMode); }
         #endregion
-        */
     }
+#endif
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselStadiumGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselStadiumGeneratorMode.cs
@@ -10,18 +10,18 @@ using UnityEditor.ShortcutManagement;
 
 namespace Chisel.Editors
 {
+// Disabled, for the time being, because this generator has not been implemented yet
+#if false
     public sealed class ChiselStadiumGeneratorMode : ChiselGeneratorToolMode
     {
         const string kToolName = ChiselStadium.kNodeTypeName;
         public override string ToolName => kToolName;
 
-        // Commented out, for the time being, because this generator has not been implemented yet
-        /*
         #region Keyboard Shortcut
         const string kToolShotcutName = ChiselKeyboardDefaults.ShortCutCreateBase + kToolName;
         [Shortcut(kToolShotcutName, ChiselKeyboardDefaults.StadiumBuilderModeKey, ChiselKeyboardDefaults.StadiumBuilderModeModifiers, displayName = kToolShotcutName)]
         public static void StartGeneratorMode() { ChiselEditModeManager.EditModeType = typeof(ChiselStadiumGeneratorMode); }
         #endregion
-        */
     }
+#endif
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselTorusGeneratorMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModeTools/ChiselTorusGeneratorMode.cs
@@ -10,18 +10,18 @@ using UnityEditor.ShortcutManagement;
 
 namespace Chisel.Editors
 {
+// Disabled, for the time being, because this generator has not been implemented yet
+#if false
     public sealed class ChiselTorusGeneratorMode : ChiselGeneratorToolMode
     {
         const string kToolName = ChiselTorus.kNodeTypeName;
         public override string ToolName => kToolName;
 
-        // Commented out, for the time being, because this generator has not been implemented yet
-        /*
         #region Keyboard Shortcut
         const string kToolShotcutName = ChiselKeyboardDefaults.ShortCutCreateBase + kToolName;
         [Shortcut(kToolShotcutName, ChiselKeyboardDefaults.TorusBuilderModeKey, ChiselKeyboardDefaults.TorusBuilderModeModifiers, displayName = kToolShotcutName)]
         public static void StartGeneratorMode() { ChiselEditModeManager.EditModeType = typeof(ChiselTorusGeneratorMode); }
         #endregion
-        */
     }
+#endif
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/NamedItemsPropertyDrawer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/NamedItemsPropertyDrawer.cs
@@ -1,0 +1,81 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Chisel;
+using Chisel.Core;
+
+namespace Chisel.Editors
+{
+    // TODO: see if we can get this to work on any array instead
+    [CustomPropertyDrawer(typeof(NamedItemsAttribute))]
+    public sealed class NamedItemsPropertyDrawer : PropertyDrawer
+    {
+        static readonly GUIContent kMissingSurfacesContents             = new GUIContent("This generator is not set up properly and doesn't have the correct number of surfaces.");
+        static readonly GUIContent kMultipleDifferentSurfacesContents   = new GUIContent("Multiple generators are selected with different surfaces.");
+
+        static GUIContent tempPropertyContent = new GUIContent();
+
+        public override void OnGUI(Rect position, SerializedProperty surfacesArrayProperty, GUIContent label)
+        {
+            NamedItemsAttribute namedItems = attribute as NamedItemsAttribute;
+
+            if (surfacesArrayProperty.type != nameof(ChiselSurfaceDefinition))
+            {
+                Debug.Assert(false);
+                return;
+            }
+
+            surfacesArrayProperty.Next(true);
+
+            if (namedItems.fixedSize > 0 && surfacesArrayProperty.arraySize != namedItems.fixedSize)
+            {
+                EditorGUILayout.HelpBox(kMissingSurfacesContents.text, MessageType.Warning);
+            }
+
+            if (surfacesArrayProperty.hasMultipleDifferentValues)
+            {
+                // TODO: figure out how to detect if we have multiple selected generators with arrays of same size, or not
+                EditorGUILayout.HelpBox(kMultipleDifferentSurfacesContents.text, MessageType.None);
+                return;
+            }
+
+            if (surfacesArrayProperty.arraySize == 0)
+                return;
+
+            EditorGUI.BeginChangeCheck();
+            var path            = surfacesArrayProperty.propertyPath;
+            var surfacesVisible = SessionState.GetBool(path, false);
+            surfacesVisible = EditorGUILayout.Foldout(surfacesVisible, label);
+            if (EditorGUI.EndChangeCheck())
+                SessionState.SetBool(path, surfacesVisible);
+            if (!surfacesVisible)
+                return;
+            
+            EditorGUI.indentLevel++;
+            SerializedProperty elementProperty;
+            int startIndex = 0;
+            if (namedItems.surfaceNames != null &&
+                namedItems.surfaceNames.Length > 0)
+            {
+                startIndex = namedItems.surfaceNames.Length;
+                for (int i = 0; i < Mathf.Min(namedItems.surfaceNames.Length, surfacesArrayProperty.arraySize); i++)
+                {
+                    elementProperty = surfacesArrayProperty.GetArrayElementAtIndex(i);
+                    tempPropertyContent.text = namedItems.surfaceNames[i];
+                    EditorGUILayout.PropertyField(elementProperty, tempPropertyContent, true);
+                }
+            }
+
+            for (int i = startIndex; i < surfacesArrayProperty.arraySize; i++)
+            {
+                tempPropertyContent.text = string.Format(namedItems.overflow, (i - startIndex) + 1);
+                elementProperty = surfacesArrayProperty.GetArrayElementAtIndex(i);
+                EditorGUILayout.PropertyField(elementProperty, tempPropertyContent, true);
+            }
+            EditorGUI.indentLevel--;
+        }
+    }
+}

--- a/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/NamedItemsPropertyDrawer.cs.meta
+++ b/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/NamedItemsPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55f6c28cdf6b042468baba4eeda39e8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Removed need for creating inspectors for generators, they will show the contents of the definition classes instead. Regular unity attributes will work there, just like with monobehaviours