### PR TITLE
Fix 2020.1.0a compatibility and Infinite Pointer Plane Glitch

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselEditableOutline.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselEditableOutline.cs
@@ -901,7 +901,7 @@ namespace Chisel.Editors
                     if (captureControl)
                     {
                         SetControl(evt, 0);
-                        Snapping.ActiveAxes = Axes.XYZ;
+                        UnitySceneExtensions.Snapping.ActiveAxes = Axes.XYZ;
                         SceneView.RepaintAll();
                     }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselEditableOutline.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselEditableOutline.cs
@@ -8,6 +8,7 @@ using Chisel;
 using Chisel.Core;
 using Chisel.Components;
 using UnitySceneExtensions;
+using Snapping = UnitySceneExtensions.Snapping;
 
 namespace Chisel.Editors
 {
@@ -901,7 +902,7 @@ namespace Chisel.Editors
                     if (captureControl)
                     {
                         SetControl(evt, 0);
-                        UnitySceneExtensions.Snapping.ActiveAxes = Axes.XYZ;
+                        Snapping.ActiveAxes = Axes.XYZ;
                         SceneView.RepaintAll();
                     }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeEditor.cs
@@ -356,7 +356,7 @@ namespace Chisel.Editors
         protected abstract void InitInspector();
 
         protected abstract void OnInspector();
-        protected virtual bool OnGeneratorValidate(T generator) { return generator != null && generator.isActiveAndEnabled; }
+        protected virtual bool OnGeneratorValidate(T generator) { return generator.isActiveAndEnabled; }
         protected virtual void OnGeneratorSelected(T generator) { }
         protected virtual void OnGeneratorDeselected(T generator) { }
         protected abstract void OnScene(SceneView sceneView, T generator);

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Base/ChiselNodeEditor.cs
@@ -356,7 +356,7 @@ namespace Chisel.Editors
         protected abstract void InitInspector();
 
         protected abstract void OnInspector();
-        protected virtual bool OnGeneratorValidate(T generator) { return generator.isActiveAndEnabled; }
+        protected virtual bool OnGeneratorValidate(T generator) { return generator != null && generator.isActiveAndEnabled; }
         protected virtual void OnGeneratorSelected(T generator) { }
         protected virtual void OnGeneratorDeselected(T generator) { }
         protected abstract void OnScene(SceneView sceneView, T generator);

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselLinearStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselLinearStairsEditor.cs
@@ -201,7 +201,7 @@ namespace Chisel.Editors
                 var bounds          = currentDefinition.bounds;
                 var cameraPosition  = Camera.current.transform.position;
 
-                var steps		    = Snapping.MoveSnappingSteps;
+                var steps		    = UnitySceneExtensions.Snapping.MoveSnappingSteps;
                 steps.y			    = stepHeight;
                 
                 EditorGUI.BeginChangeCheck();

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselLinearStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselLinearStairsEditor.cs
@@ -8,6 +8,7 @@ using Chisel;
 using Chisel.Core;
 using Chisel.Components;
 using UnitySceneExtensions;
+using Snapping = UnitySceneExtensions.Snapping;
 
 namespace Chisel.Editors
 {
@@ -201,7 +202,7 @@ namespace Chisel.Editors
                 var bounds          = currentDefinition.bounds;
                 var cameraPosition  = Camera.current.transform.position;
 
-                var steps		    = UnitySceneExtensions.Snapping.MoveSnappingSteps;
+                var steps		    = Snapping.MoveSnappingSteps;
                 steps.y			    = stepHeight;
                 
                 EditorGUI.BeginChangeCheck();

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
@@ -8,6 +8,7 @@ using Chisel;
 using Chisel.Core;
 using Chisel.Components;
 using UnitySceneExtensions;
+using Snapping = UnitySceneExtensions.Snapping;
 
 namespace Chisel.Editors
 {
@@ -178,7 +179,7 @@ namespace Chisel.Editors
             
             
             // TODO: put somewhere else
-            if (!UnitySceneExtensions.Snapping.RotateSnappingActive)
+            if (!Snapping.RotateSnappingActive)
             {
                 return rotatedStartAngle + rotatedAngleOffset;
             }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
@@ -178,7 +178,7 @@ namespace Chisel.Editors
             
             
             // TODO: put somewhere else
-            if (!Snapping.RotateSnappingActive)
+            if (!UnitySceneExtensions.Snapping.RotateSnappingActive)
             {
                 return rotatedStartAngle + rotatedAngleOffset;
             }

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModes/ChiselSurfaceEditMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModes/ChiselSurfaceEditMode.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnitySceneExtensions;
 using Chisel.Utilities;
 using UnityEditor.ShortcutManagement;
+using Snapping = UnitySceneExtensions.Snapping;
 
 namespace Chisel.Editors
 {
@@ -112,7 +113,7 @@ namespace Chisel.Editors
                 return;
 
             var grid				= UnitySceneExtensions.Grid.defaultGrid;
-            var gridSnappedPoint	= UnitySceneExtensions.Snapping.SnapPoint(intersectionPoint, grid);
+            var gridSnappedPoint	= Snapping.SnapPoint(intersectionPoint, grid);
 
             var worldPlane  = surfaceReference.WorldPlane.Value;
 
@@ -358,9 +359,9 @@ namespace Chisel.Editors
 
         static float SnapAngle(float rotatedAngle)
         {
-            if (!UnitySceneExtensions.Snapping.RotateSnappingEnabled)
+            if (!Snapping.RotateSnappingEnabled)
                 return rotatedAngle;
-            return ((int)(rotatedAngle / UnitySceneExtensions.Snapping.RotateSnappingStep)) * UnitySceneExtensions.Snapping.RotateSnappingStep;
+            return ((int)(rotatedAngle / Snapping.RotateSnappingStep)) * Snapping.RotateSnappingStep;
         }
 
         #endregion
@@ -860,9 +861,9 @@ namespace Chisel.Editors
             var deltaVector = tangent  * Vector3.Dot(tangent,  worldSpaceMovement) +
                               biNormal * Vector3.Dot(biNormal, worldSpaceMovement);
 
-            if (UnitySceneExtensions.Snapping.AxisLockX) deltaVector.x = 0;
-            if (UnitySceneExtensions.Snapping.AxisLockY) deltaVector.y = 0;
-            if (UnitySceneExtensions.Snapping.AxisLockZ) deltaVector.z = 0;
+            if (Snapping.AxisLockX) deltaVector.x = 0;
+            if (Snapping.AxisLockY) deltaVector.y = 0;
+            if (Snapping.AxisLockZ) deltaVector.z = 0;
 
             worldDragDeltaVector = deltaVector;
         }

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModes/ChiselSurfaceEditMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModes/ChiselSurfaceEditMode.cs
@@ -133,7 +133,7 @@ namespace Chisel.Editors
             {
                 float dist;
                 var ray = new Ray(gridSnappedPoint, xAxis);
-                if ((snapAxis & Axis.X) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                if ((snapAxis & Axis.X) != Axis.None && worldPlane.SignedRaycast(ray, out dist))
                 {
                     var planePoint = ray.GetPoint(dist);
                     var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
@@ -144,7 +144,7 @@ namespace Chisel.Editors
                     }
                 }
                 ray.direction = yAxis;
-                if ((snapAxis & Axis.Y) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                if ((snapAxis & Axis.Y) != Axis.None && worldPlane.SignedRaycast(ray, out dist))
                 {
                     var planePoint = ray.GetPoint(dist);
                     var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
@@ -155,7 +155,7 @@ namespace Chisel.Editors
                     }
                 }
                 ray.direction = zAxis;
-                if ((snapAxis & Axis.Z) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                if ((snapAxis & Axis.Z) != Axis.None && worldPlane.SignedRaycast(ray, out dist))
                 {
                     var planePoint = ray.GetPoint(dist);
                     var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
@@ -271,7 +271,7 @@ namespace Chisel.Editors
 
                     float dist;
                     var ray = new Ray(snappedPoint, xAxis);
-                    if ((edgeSnapAxis & Axis.X) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                    if ((edgeSnapAxis & Axis.X) != Axis.None && worldPlane.SignedRaycast(ray, out dist))
                     {
                         var planePoint = ray.GetPoint(dist);
                         var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
@@ -282,7 +282,7 @@ namespace Chisel.Editors
                         }
                     }
                     ray.direction = yAxis;
-                    if ((edgeSnapAxis & Axis.Y) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                    if ((edgeSnapAxis & Axis.Y) != Axis.None && worldPlane.SignedRaycast(ray, out dist))
                     {
                         var planePoint = ray.GetPoint(dist);
                         var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
@@ -293,7 +293,7 @@ namespace Chisel.Editors
                         }
                     }
                     ray.direction = zAxis;
-                    if ((edgeSnapAxis & Axis.Z) != Axis.None && worldPlane.UnsignedRaycast(ray, out dist))
+                    if ((edgeSnapAxis & Axis.Z) != Axis.None && worldPlane.SignedRaycast(ray, out dist))
                     {
                         var planePoint = ray.GetPoint(dist);
                         var abs_dist = (planePoint - intersectionPoint).magnitude * preferenceFactor;
@@ -843,7 +843,7 @@ namespace Chisel.Editors
             var currentWorldIntersection = worldStartPosition;                    
             var mouseRay = HandleUtility.GUIPointToWorldRay(mousePosition);
             var enter = 0.0f;
-            if (worldDragPlane.UnsignedRaycast(mouseRay, out enter))
+            if (worldDragPlane.SignedRaycast(mouseRay, out enter))
                 currentWorldIntersection = mouseRay.GetPoint(enter);
             currentWorldIntersection = SnapIntersection(currentWorldIntersection, startSurfaceReference, out pointHasSnapped);
             return currentWorldIntersection;

--- a/Packages/com.chisel.editor/Chisel/Editor/EditModes/ChiselSurfaceEditMode.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditModes/ChiselSurfaceEditMode.cs
@@ -112,7 +112,7 @@ namespace Chisel.Editors
                 return;
 
             var grid				= UnitySceneExtensions.Grid.defaultGrid;
-            var gridSnappedPoint	= Snapping.SnapPoint(intersectionPoint, grid);
+            var gridSnappedPoint	= UnitySceneExtensions.Snapping.SnapPoint(intersectionPoint, grid);
 
             var worldPlane  = surfaceReference.WorldPlane.Value;
 
@@ -358,9 +358,9 @@ namespace Chisel.Editors
 
         static float SnapAngle(float rotatedAngle)
         {
-            if (!Snapping.RotateSnappingEnabled)
+            if (!UnitySceneExtensions.Snapping.RotateSnappingEnabled)
                 return rotatedAngle;
-            return ((int)(rotatedAngle / Snapping.RotateSnappingStep)) * Snapping.RotateSnappingStep;
+            return ((int)(rotatedAngle / UnitySceneExtensions.Snapping.RotateSnappingStep)) * UnitySceneExtensions.Snapping.RotateSnappingStep;
         }
 
         #endregion

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ExtrustionHandle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ExtrustionHandle.cs
@@ -63,7 +63,7 @@ namespace Chisel.Editors
         public static ExtrusionState Do(int id, Rect dragArea, ref Vector3 position, Axis axis, UnitySceneExtensions.SceneHandles.CapFunction capFunction, float? snappingSteps = null)
         {
             if (!snappingSteps.HasValue)
-                snappingSteps = Snapping.MoveSnappingSteps[(int)axis];
+                snappingSteps = UnitySceneExtensions.Snapping.MoveSnappingSteps[(int)axis];
             return Do(id, dragArea, ref position, axis, snappingSteps.Value, capFunction);
         }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ExtrustionHandle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ExtrustionHandle.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using Chisel.Utilities;
 using UnitySceneExtensions;
+using Snapping = UnitySceneExtensions.Snapping;
 
 namespace Chisel.Editors
 {
@@ -63,7 +64,7 @@ namespace Chisel.Editors
         public static ExtrusionState Do(int id, Rect dragArea, ref Vector3 position, Axis axis, UnitySceneExtensions.SceneHandles.CapFunction capFunction, float? snappingSteps = null)
         {
             if (!snappingSteps.HasValue)
-                snappingSteps = UnitySceneExtensions.Snapping.MoveSnappingSteps[(int)axis];
+                snappingSteps = Snapping.MoveSnappingSteps[(int)axis];
             return Do(id, dragArea, ref position, axis, snappingSteps.Value, capFunction);
         }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/PointDrawing.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/PointDrawing.cs
@@ -77,14 +77,14 @@ namespace Chisel.Editors
                     var bestDist = float.PositiveInfinity;
                     float dist;
 
-                    if (surfaceGridPlane.UnsignedRaycast(forwardRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = forwardRay.GetPoint(dist); } }
-                    if (surfaceGridPlane.UnsignedRaycast(backRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = backRay   .GetPoint(dist); } }
-                    if (surfaceGridPlane.UnsignedRaycast(leftRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = leftRay   .GetPoint(dist); } }
-                    if (surfaceGridPlane.UnsignedRaycast(rightRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = rightRay  .GetPoint(dist); } }
+                    if (surfaceGridPlane.SignedRaycast(forwardRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = forwardRay.GetPoint(dist); } }
+                    if (surfaceGridPlane.SignedRaycast(backRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = backRay   .GetPoint(dist); } }
+                    if (surfaceGridPlane.SignedRaycast(leftRay,    out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = leftRay   .GetPoint(dist); } }
+                    if (surfaceGridPlane.SignedRaycast(rightRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = rightRay  .GetPoint(dist); } }
                     if (bestDist > 100000) // prefer rays on the active-grid, only go up/down from the active-grid when we have no other choice
                     {
-                        if (surfaceGridPlane.UnsignedRaycast(upRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = upRay     .GetPoint(dist); } }
-                        if (surfaceGridPlane.UnsignedRaycast(downRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = downRay   .GetPoint(dist); } }
+                        if (surfaceGridPlane.SignedRaycast(upRay,   out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = upRay     .GetPoint(dist); } }
+                        if (surfaceGridPlane.SignedRaycast(downRay, out dist)) { var abs_dist = Mathf.Abs(dist); if (abs_dist < bestDist) { bestDist = abs_dist; surfaceGridCenter = downRay   .GetPoint(dist); } }
                     }
 
                     // TODO: try to snap the new surface grid point in other directions on the active-grid? (do we need to?)

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
@@ -456,7 +456,7 @@ namespace Chisel.Editors
                 var gridPlane = UnitySceneExtensions.Grid.ActiveGrid.PlaneXZ;
                 var mouseRay = UnityEditor.HandleUtility.GUIPointToWorldRay(mousePosition);
                 var dist = 0.0f;
-                if (gridPlane.UnsignedRaycast(mouseRay, out dist))
+                if (gridPlane.SignedRaycast(mouseRay, out dist))
                     return new PlaneIntersection(mouseRay.GetPoint(dist), gridPlane);
             }
             return null;

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
@@ -537,7 +537,7 @@ namespace UnitySceneExtensions
             var rotation    = Quaternion.FromToRotation(normal, worldSlidePlane.normal);
             var alternativePlane = new Plane(normal, origin);
             var dist = 0.0f;
-            if (!alternativePlane.UnsignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
+            if (!alternativePlane.SignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
 
             worldPlanePosition = (rotation * (worldRay.GetPoint(dist) - origin)) + origin;
             return true;
@@ -564,7 +564,7 @@ namespace UnitySceneExtensions
                 return GetIntersectionOnAlternativePlane(worldRay, normal, origin, out worldPlanePosition);
             }
 
-            if (!worldSlidePlane.UnsignedRaycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
+            if (!worldSlidePlane.SignedRaycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
             if (dist > camera.farClipPlane)
             {
                 var normal = worldSlideGrid.GetClosestAxisVector(forward);
@@ -572,7 +572,7 @@ namespace UnitySceneExtensions
                 return GetIntersectionOnAlternativePlane(worldRay, normal, origin, out worldPlanePosition);
             } else
             { 
-                if (!worldSlidePlane.UnsignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
+                if (!worldSlidePlane.SignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
                 worldPlanePosition = worldRay.GetPoint(Mathf.Abs(dist));
                 return true;
             }

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
@@ -503,7 +503,6 @@ namespace UnitySceneExtensions
             this.worldSnappedPosition	= worldSlideOrigin;
             
             this.worldSlidePlane		= this.worldSlideGrid.PlaneXZ;
-            this.worldSlidePlane.Translate(-this.worldSlideOrigin);
             
             this.snapResult				= SnapResult3D.None;
 
@@ -564,7 +563,7 @@ namespace UnitySceneExtensions
                 return GetIntersectionOnAlternativePlane(worldRay, normal, origin, out worldPlanePosition);
             }
 
-            if (!worldSlidePlane.SignedRaycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
+            if (!worldSlidePlane.Raycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
             if (dist > camera.farClipPlane)
             {
                 var normal = worldSlideGrid.GetClosestAxisVector(forward);
@@ -573,7 +572,7 @@ namespace UnitySceneExtensions
             } else
             { 
                 if (!worldSlidePlane.SignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
-                worldPlanePosition = worldRay.GetPoint(Mathf.Abs(dist));
+                worldPlanePosition = worldRay.GetPoint(dist);
                 return true;
             }
         }

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
@@ -564,8 +564,8 @@ namespace UnitySceneExtensions
                 return GetIntersectionOnAlternativePlane(worldRay, normal, origin, out worldPlanePosition);
             }
 
-            if (!worldSlidePlane.Raycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
-            if (dist > camera.farClipPlane)
+            if (!worldSlidePlane.UnsignedRaycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
+            if (Mathf.Abs(dist) > camera.farClipPlane)
             {
                 var normal = worldSlideGrid.GetClosestAxisVector(forward);
                 var origin = worldSlidePlane.ClosestPointOnPlane(camera.transform.position) + (normal * camera.farClipPlane);
@@ -573,7 +573,7 @@ namespace UnitySceneExtensions
             } else
             { 
                 if (!worldSlidePlane.UnsignedRaycast(worldRay, out dist)) { worldPlanePosition = worldSlideOrigin; return false; }
-                worldPlanePosition = worldRay.GetPoint(dist);
+                worldPlanePosition = worldRay.GetPoint(Mathf.Abs(dist));
                 return true;
             }
         }

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Snapping.cs
@@ -565,7 +565,7 @@ namespace UnitySceneExtensions
             }
 
             if (!worldSlidePlane.UnsignedRaycast(worldRay, out dist)) { dist = float.PositiveInfinity; }
-            if (Mathf.Abs(dist) > camera.farClipPlane)
+            if (dist > camera.farClipPlane)
             {
                 var normal = worldSlideGrid.GetClosestAxisVector(forward);
                 var origin = worldSlidePlane.ClosestPointOnPlane(camera.transform.position) + (normal * camera.farClipPlane);

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Utilities/Plane.Extension.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Utilities/Plane.Extension.cs
@@ -24,7 +24,7 @@ namespace UnitySceneExtensions
                                       (c * translation.z)));
         }
 #endif
-        public static bool UnsignedRaycast(this Plane plane, Ray ray, out float enter)
+        public static bool SignedRaycast(this Plane plane, Ray ray, out float enter)
         {
             float vdot = Vector3.Dot(ray.direction, plane.normal);
             float ndot = -Vector3.Dot(ray.origin, plane.normal) - plane.distance;


### PR DESCRIPTION
This allows the 2020.1.0a9 auto-importer to successfully import/upgrade the project (without breaking compatibility with earlier versions of Unity).

This also improves on a behaviour that would cause secondary points in the editor gizmos to go off to infinity at certain plane position/orientations.