### PR TITLE
Handles/improved overlapping visualization + mouse movement + compile under 2019.2

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
@@ -65,8 +65,13 @@ namespace Chisel.Components
                 return false;
 
             var staticFlags = UnityEditor.GameObjectUtility.GetStaticEditorFlags(model.gameObject);
+#if UNITY_2019_2_OR_NEWER
+            if ((staticFlags & UnityEditor.StaticEditorFlags.ContributeGI) != UnityEditor.StaticEditorFlags.ContributeGI)
+                return false;
+#else
             if ((staticFlags & UnityEditor.StaticEditorFlags.LightmapStatic) != UnityEditor.StaticEditorFlags.LightmapStatic)
                 return false;
+#endif
 
             for (int i = 0; i < model.generatedMeshes.Length; i++)
             {
@@ -95,8 +100,12 @@ namespace Chisel.Components
                     continue;
 
                 var staticFlags = UnityEditor.GameObjectUtility.GetStaticEditorFlags(model.gameObject);
-                if ((!model.AutoRebuildUVs && !force) ||
-                    (staticFlags & UnityEditor.StaticEditorFlags.LightmapStatic) != UnityEditor.StaticEditorFlags.LightmapStatic)
+#if UNITY_2019_2_OR_NEWER
+                var lightmapStatic = (staticFlags & UnityEditor.StaticEditorFlags.ContributeGI) == UnityEditor.StaticEditorFlags.ContributeGI;
+#else
+                var lightmapStatic = (staticFlags & UnityEditor.StaticEditorFlags.LightmapStatic) == UnityEditor.StaticEditorFlags.LightmapStatic;
+#endif
+                if ((!model.AutoRebuildUVs && !force) || !lightmapStatic)
                     continue;
 
                 for (int i = 0; i < model.generatedMeshes.Length; i++)
@@ -352,7 +361,12 @@ namespace Chisel.Components
                 if (generatedMesh.needsUpdate || forceUpdate)
                 {
 #if UNITY_EDITOR
-                    if ((modelState.staticFlags & UnityEditor.StaticEditorFlags.LightmapStatic) == UnityEditor.StaticEditorFlags.LightmapStatic)
+#if UNITY_2019_2_OR_NEWER
+                    var lightmapStatic = (modelState.staticFlags & UnityEditor.StaticEditorFlags.ContributeGI) == UnityEditor.StaticEditorFlags.ContributeGI;
+#else
+                    var lightmapStatic = (modelState.staticFlags & UnityEditor.StaticEditorFlags.LightmapStatic) == UnityEditor.StaticEditorFlags.LightmapStatic;
+#endif
+                    if (lightmapStatic)
                     {
                         generatedMesh.renderComponents.meshRenderer.realtimeLightmapIndex = -1;
                         generatedMesh.renderComponents.meshRenderer.lightmapIndex         = -1;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -458,7 +458,12 @@ namespace Chisel.Editors
             if (targets == null)
                 return false;
 
+#if UNITY_2019_2_OR_NEWER
+            bool lightmapStatic = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.ContributeGI) != 0;
+#else
             bool lightmapStatic = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.LightmapStatic) != 0;
+#endif
+
             if (lightmapStatic)
                 return false;
 
@@ -470,14 +475,22 @@ namespace Chisel.Editors
 
         void LightmapStaticSettings()
         {
+#if UNITY_2019_2_OR_NEWER
+            bool lightmapStatic = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.ContributeGI) != 0;
+#else
             bool lightmapStatic = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.LightmapStatic) != 0;
+#endif
 
             EditorGUI.BeginChangeCheck();
             lightmapStatic = EditorGUILayout.Toggle(LightmapStaticContents, lightmapStatic);
 
             if (EditorGUI.EndChangeCheck())
             {
+#if UNITY_2019_2_OR_NEWER
+                SceneModeUtility.SetStaticFlags(gameObjectsSerializedObject.targetObjects, (int)StaticEditorFlags.ContributeGI, lightmapStatic);
+#else
                 SceneModeUtility.SetStaticFlags(gameObjectsSerializedObject.targetObjects, (int)StaticEditorFlags.LightmapStatic, lightmapStatic);
+#endif
                 gameObjectsSerializedObject.Update();
             }
         }
@@ -676,7 +689,11 @@ namespace Chisel.Editors
                 return;
             }
 
+#if UNITY_2019_2_OR_NEWER
+            bool enableSettings = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.ContributeGI) != 0;
+#else
             bool enableSettings = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.LightmapStatic) != 0;
+#endif
             if (enableSettings)
             {
                 EditorGUILayout.Space();

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -688,7 +688,7 @@ namespace Chisel.Editors
                 EditorGUILayout.HelpBox(GINotEnabledInfoContents.text, MessageType.Info);
                 return;
             }
-
+             
 #if UNITY_2019_2_OR_NEWER
             bool enableSettings = (staticEditorFlagsProp.intValue & (int)StaticEditorFlags.ContributeGI) != 0;
 #else

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/ChiselUnityEventsManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/ChiselUnityEventsManager.cs
@@ -155,6 +155,11 @@ namespace Chisel.Editors
                     grid = UnitySceneExtensions.Grid.ActiveGrid;
                 grid.Render(sceneView);
             }
+
+            if (UnitySceneExtensions.Grid.debugGrid != null)
+            {
+                UnitySceneExtensions.Grid.debugGrid.Render(sceneView);
+            }
         }
 
         static void OnSceneGUI(SceneView sceneView)

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/BoxExtrusionHandle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/BoxExtrusionHandle.cs
@@ -123,7 +123,7 @@ namespace Chisel.Editors
 
                 if (s_Points.Count <= 2)
                 {
-                    PointDrawing.PointDrawHandle(dragArea, ref s_Points, out s_Transformation, out s_ModelBeneathCursor, UnitySceneExtensions.SceneHandles.OutlinedDotHandleCap);
+                    PointDrawing.PointDrawHandle(dragArea, ref s_Points, out s_Transformation, out s_ModelBeneathCursor, releaseOnMouseUp: false, UnitySceneExtensions.SceneHandles.OutlinedDotHandleCap);
 
                     if (s_Points.Count <= 1)
                     {
@@ -132,6 +132,7 @@ namespace Chisel.Editors
 
                     if (s_Points.Count > 2)
                     {
+                        PointDrawing.Release();
                         s_Points[2] = s_Points[0];
                         return BoxExtrusionState.Create;
                     }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/PointDrawing.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/PointDrawing.cs
@@ -15,10 +15,10 @@ namespace Chisel.Editors
     public sealed class PointDrawing
     {
         internal static int s_PointDrawingHash = "PointDrawingHash".GetHashCode();
-        public static void PointDrawHandle(Rect dragArea, ref List<Vector3> points, out Matrix4x4 transformation, out ChiselModel modelBeneathCursor, UnitySceneExtensions.SceneHandles.CapFunction capFunction)
+        public static void PointDrawHandle(Rect dragArea, ref List<Vector3> points, out Matrix4x4 transformation, out ChiselModel modelBeneathCursor, bool releaseOnMouseUp = true, UnitySceneExtensions.SceneHandles.CapFunction capFunction = null)
         {
             var id = GUIUtility.GetControlID(s_PointDrawingHash, FocusType.Keyboard);
-            PointDrawing.Do(id, dragArea, ref points, out transformation, out modelBeneathCursor, capFunction);
+            PointDrawing.Do(id, dragArea, ref points, out transformation, out modelBeneathCursor, releaseOnMouseUp, capFunction);
         }
 
 
@@ -27,6 +27,8 @@ namespace Chisel.Editors
         {
             s_CurrentPointIndex = 0;
             UnitySceneExtensions.Grid.HoverGrid = null;
+            s_MousePosition = Event.current.mousePosition;
+            s_MouseJumping = false;
         }
 
         private const float kMaxHandleDistance = 3.0f;
@@ -36,6 +38,8 @@ namespace Chisel.Editors
         private static Matrix4x4            s_Transform;
         private static Matrix4x4            s_InvTransform;
         private static Snapping2D			s_Snapping2D = new Snapping2D();
+        private static Vector2			    s_MousePosition = Vector2.zero;
+        private static bool			        s_MouseJumping = false;
 
         // TODO: put these constants somewhere
         public const KeyCode    kCancelKey			= KeyCode.Escape;
@@ -98,6 +102,8 @@ namespace Chisel.Editors
 
             if (s_StartIntersection != null)
             {
+                if (!dragArea.Contains(mousePosition))
+                    return null;
                 if (s_Snapping2D.DragTo(mousePosition, SnappingMode.Always))
                 {
                     UnitySceneExtensions.Grid.HoverGrid = s_Snapping2D.WorldSlideGrid;
@@ -127,27 +133,48 @@ namespace Chisel.Editors
             }
         }
 
+        static void Acquire(int controlID)
+        {
+            GUIUtility.hotControl = GUIUtility.keyboardControl = controlID;
+            EditorGUIUtility.SetWantsMouseJumping(1);
+            s_MouseJumping = true;
+        }
+
+        public static void Release()
+        {
+            GUIUtility.hotControl = 0;
+            GUIUtility.keyboardControl = 0;
+            EditorGUIUtility.SetWantsMouseJumping(0);
+            s_MousePosition = Event.current.mousePosition;
+            s_MouseJumping = false;
+        }
+
         static void Commit(Event evt, Rect dragArea, ref List<Vector3> points)
         {
+            var newPoint = GetPointAtPosition(s_MousePosition, dragArea);
+            if (!newPoint.HasValue)
+            {
+                Cancel(evt, ref points);
+                return;
+            }
+
             s_CurrentPointIndex++;
-            UpdatePoints(points, GetPointAtPosition(evt.mousePosition, dragArea));
+            UpdatePoints(points, newPoint);
 
             // reset the starting position
-            s_StartIntersection = ChiselClickSelectionManager.GetPlaneIntersection(evt.mousePosition, dragArea);
+            s_StartIntersection = ChiselClickSelectionManager.GetPlaneIntersection(s_MousePosition, dragArea);
             evt.Use();
         }
 
         static void Cancel(Event evt, ref List<Vector3> points)
         {
-            GUIUtility.hotControl = 0;
-            GUIUtility.keyboardControl = 0;
-            evt.Use();
+            Release();
 
             Reset();
             points.Clear();
         }
 
-        public static void Do(int id, Rect dragArea, ref List<Vector3> points, out Matrix4x4 transformation, out ChiselModel modelBeneathCursor, UnitySceneExtensions.SceneHandles.CapFunction capFunction)
+        public static void Do(int id, Rect dragArea, ref List<Vector3> points, out Matrix4x4 transformation, out ChiselModel modelBeneathCursor, bool releaseOnMouseUp = true, UnitySceneExtensions.SceneHandles.CapFunction capFunction = null)
         {
             modelBeneathCursor = null;
             var evt = Event.current;
@@ -214,7 +241,15 @@ namespace Chisel.Editors
                         GUIUtility.hotControl != id)
                         break;
 
-                    UpdatePoints(points, GetPointAtPosition(evt.mousePosition, dragArea));
+
+                    if (s_MouseJumping)
+                        s_MousePosition += evt.delta;
+                    else
+                        s_MousePosition = Event.current.mousePosition;
+
+                    var newPoint = GetPointAtPosition(s_MousePosition, dragArea);
+                    if (newPoint.HasValue)
+                        UpdatePoints(points, newPoint);
                     SceneView.RepaintAll();
                     break;
                 }
@@ -223,7 +258,15 @@ namespace Chisel.Editors
                     if (GUIUtility.hotControl != id)
                         break;
 
-                    UpdatePoints(points, GetPointAtPosition(evt.mousePosition, dragArea));
+                    if (s_MouseJumping)
+                        s_MousePosition += evt.delta;
+                    else
+                        s_MousePosition = Event.current.mousePosition;
+
+                    var newPoint = GetPointAtPosition(s_MousePosition, dragArea);
+                    if (newPoint.HasValue)
+                        UpdatePoints(points, newPoint);
+
                     GUI.changed = true;
                     evt.Use();
                     break;
@@ -233,7 +276,9 @@ namespace Chisel.Editors
                     if (SceneHandles.InCameraOrbitMode)
                         break;
 
-                    if (GUIUtility.hotControl != 0)
+                    var hotControl = GUIUtility.hotControl;
+                    if (hotControl != 0 &&
+                        hotControl != id)
                         break;
 
                     if ((UnityEditor.HandleUtility.nearestControl != id || evt.button != 0) &&
@@ -244,8 +289,11 @@ namespace Chisel.Editors
                         break;
 
                     s_CurrentPointIndex++;
-                    GUIUtility.hotControl = GUIUtility.keyboardControl = id;
-                    EditorGUIUtility.SetWantsMouseJumping(1);
+                    if (hotControl != id)
+                    {
+                        Acquire(id);
+                        s_MousePosition = evt.mousePosition;
+                    }
                     evt.Use();
                     break;
                 }
@@ -254,16 +302,23 @@ namespace Chisel.Editors
                     if (GUIUtility.hotControl != id || (evt.button != 0 && evt.button != 2))
                         break;
 
-                    GUIUtility.hotControl = 0;
-                    GUIUtility.keyboardControl = 0;
+                    if (releaseOnMouseUp)
+                        Release();
                     evt.Use();
-                    EditorGUIUtility.SetWantsMouseJumping(0);
+
 
                     // reset the starting position
-                    UpdatePoints(points, GetPointAtPosition(evt.mousePosition, dragArea));
+                    var newPoint = GetPointAtPosition(s_MousePosition, dragArea);
+                    if (!newPoint.HasValue)
+                    {
+                        Cancel(evt, ref points);
+                        break;
+                    }
+
+                    UpdatePoints(points, newPoint);
                     break;
                 }
-            }
+            } 
             if (s_StartIntersection != null)
             {
                 modelBeneathCursor = s_StartIntersection.model;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ShapeExtrusionHandle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ShapeExtrusionHandle.cs
@@ -54,7 +54,7 @@ namespace Chisel.Editors
 
             var pointCount = s_ExtrusionMode ? s_Points.Count - 1 : s_Points.Count;
 
-            if ((s_Points[pointCount - 1] - s_Points[0]).sqrMagnitude < kDistanceEpsilon)
+            if ((s_Points[pointCount - 1] - s_Points[0]).sqrMagnitude < PointDrawing.kDistanceEpsilon)
                 pointCount--;
 
             if (s_Curve2D.controlPoints.Length != pointCount)
@@ -72,7 +72,6 @@ namespace Chisel.Editors
             return (s_Points[s_Points.Count - 1] - s_Points[1])[(int)axis];
         }
 
-        const float kDistanceEpsilon = 0.0001f;
 
         public static ShapeExtrusionState Do(Rect dragArea, out Curve2D shape, out float height, out ChiselModel modelBeneathCursor, out Matrix4x4 transformation, Axis axis)
         {
@@ -90,7 +89,7 @@ namespace Chisel.Editors
                     if (s_Points.Count <= 3)
                         return ShapeExtrusionState.ShapeMode;
 
-                    if ((s_Points[s_Points.Count - 2] - s_Points[0]).sqrMagnitude < kDistanceEpsilon)
+                    if ((s_Points[s_Points.Count - 2] - s_Points[0]).sqrMagnitude < PointDrawing.kDistanceEpsilon)
                     {
                         s_ExtrusionMode = true;
                         s_Points[s_Points.Count - 1] = s_Points[0];

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ShapeExtrusionHandle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ShapeExtrusionHandle.cs
@@ -82,7 +82,7 @@ namespace Chisel.Editors
                 {
                     // TODO: handle snapping against own points
                     // TODO: handle ability to 'commit'
-                    PointDrawing.PointDrawHandle(dragArea, ref s_Points, out s_Transformation, out s_ModelBeneathCursor, UnitySceneExtensions.SceneHandles.OutlinedDotHandleCap);
+                    PointDrawing.PointDrawHandle(dragArea, ref s_Points, out s_Transformation, out s_ModelBeneathCursor, releaseOnMouseUp: true, UnitySceneExtensions.SceneHandles.OutlinedDotHandleCap);
 
                     if (s_Points.Count <= 1)
                         return ShapeExtrusionState.HoverMode;

--- a/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Grid.cs
+++ b/Packages/com.scene.handle.extensions/Handle Extensions/Editor/Snapping/SceneHandles.Grid.cs
@@ -43,6 +43,8 @@ namespace UnitySceneExtensions
 
         public static Grid HoverGrid { get; set; }
 
+        public static Grid debugGrid;
+
         public static Grid ActiveGrid
         {
             get

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,16 @@
 {
   "dependencies": {
-    "com.unity.burst": "1.0.0",
-    "com.unity.package-manager-ui": "2.1.2",
+    "com.unity.burst": "1.1.2",
+    "com.unity.ext.nunit": "1.0.0",
+    "com.unity.package-manager-ui": "2.2.0",
+    "com.unity.test-framework": "1.0.18",
     "com.unity.textmeshpro": "2.0.0",
     "com.unity.modules.ai": "1.0.0",
+    "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.imgui": "1.0.0",
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
     "com.unity.modules.terrain": "1.0.0",
     "com.unity.modules.terrainphysics": "1.0.0",
     "com.unity.modules.ui": "1.0.0",


### PR DESCRIPTION
When moving the mouse cursor over the horizon, it would switch to movement over a camera aligned plane to avoid making the movement going into infinity.
Unfortunately when calculating the intersection point on this alternative plane, it would rotate it incorrectly, losing one axis of movement.
I fixed this by ensuring that the shared axis between the two planes is always the same when rotating the point from one plane to another