### PR TITLE
Fix/toolbar

### DIFF
--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Poly2Mesh/Poly2Tri/Triangulation/Polygon/PolygonPoint.cs.meta
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Poly2Mesh/Poly2Tri/Triangulation/Polygon/PolygonPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a62dd5d67c944c64c92c894673114c65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Poly2Mesh/Poly2Tri/Triangulation/Polygon/PolygonSet.cs.meta
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Poly2Mesh/Poly2Tri/Triangulation/Polygon/PolygonSet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9aa7d8c6ac1bda84fa404ce9de2ad53c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/ChiselUnityEventsManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/ChiselUnityEventsManager.cs
@@ -175,18 +175,37 @@ namespace Chisel.Editors
 
         static void OnBeforeSceneGUI(SceneView sceneView)
         {
-            ChiselSceneBottomGUI.OnSceneGUI(sceneView);
+            var prevSkin = GUI.skin;
+            GUI.skin = ChiselSceneGUIStyle.GetSceneSkin(); 
+            try
+            {
+                ChiselSceneGUIStyle.Update();
+                ChiselSceneBottomGUI.OnSceneGUI(sceneView);
+            }
+            finally
+            {
+                GUI.skin = prevSkin;
+            }
         }
 
         static void OnDuringSceneGUI(SceneView sceneView)
         {
-            var dragArea = ChiselGUIUtility.GetRectForEditorWindow(sceneView);
-            GridOnSceneGUI(sceneView);
-            ChiselEditModeGUI.OnSceneGUI(sceneView, dragArea);
-            ChiselOutlineRenderer.Instance.OnSceneGUI(sceneView);
+            var prevSkin = GUI.skin;
+            GUI.skin = ChiselSceneGUIStyle.GetSceneSkin();
+            try
+            {
+                var dragArea = ChiselGUIUtility.GetRectForEditorWindow(sceneView);
+                GridOnSceneGUI(sceneView);
+                ChiselEditModeGUI.OnSceneGUI(sceneView, dragArea);
+                ChiselOutlineRenderer.Instance.OnSceneGUI(sceneView);
 
-            ChiselDragAndDropManager.Instance.OnSceneGUI(sceneView);
-            ChiselClickSelectionManager.Instance.OnSceneGUI(sceneView);
+                ChiselDragAndDropManager.Instance.OnSceneGUI(sceneView);
+                ChiselClickSelectionManager.Instance.OnSceneGUI(sceneView);
+            }
+            finally
+            {
+                GUI.skin = prevSkin;
+            }
         }
 
 #if !UNITY_2019_1_OR_NEWER

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/GUIExtensions/GUIResizableWindow.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/GUIExtensions/GUIResizableWindow.cs
@@ -51,10 +51,7 @@ namespace Chisel.Editors
             currentDraggableArea.height -= kGap + kGap;
 
             int windowId = GUIUtility.GetControlID(kWindowHash, FocusType.Passive);
-            var prevSkin = GUI.skin;
-            GUI.skin = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Scene);
-            position = GUI.Window(windowId, position, HandleWindowLogic, title);
-            GUI.skin = prevSkin;
+            position = GUI.Window(windowId, position, HandleWindowLogic, title, ChiselSceneGUIStyle.windowStyle);
 
             if (position.width < minWidth)
                 position.width = minWidth;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Hierarchy/ChiselHierarchyWindowManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Hierarchy/ChiselHierarchyWindowManager.cs
@@ -11,6 +11,35 @@ using Chisel.Components;
 
 namespace Chisel.Editors
 {
+    public sealed class GUIView
+    {
+        static PropertyInfo currentProperty;
+        static PropertyInfo hasFocusProperty;
+
+        static GUIView()
+        {
+            var type = typeof(UnityEditor.EditorWindow).Assembly.GetType("UnityEditor.GUIView");
+            currentProperty = type.GetProperty("current");
+            hasFocusProperty = type.GetProperty("hasFocus");
+        }
+
+        public static bool HasFocus
+        {
+            get
+            {
+                var currentGuiView = currentProperty.GetMethod.Invoke(null, null);
+                if (currentGuiView == null)
+                    return false;
+                
+                var hasFocusObj = hasFocusProperty.GetMethod.Invoke(currentGuiView, null);
+                if (hasFocusObj == null)
+                    return false;
+                
+                return (bool) hasFocusObj;
+            }
+        }
+    }
+
     public static class ChiselHierarchyWindowManager
     {
         public static void RenderIcon(Rect selectionRect, GUIContent icon)
@@ -27,25 +56,17 @@ namespace Chisel.Editors
         
         static void RenderHierarchyItem(int instanceID, ChiselNode node, Rect selectionRect)
         {
+            if (!ChiselSceneGUIStyle.isInitialized)
+                return;
             var model = node as ChiselModel;
             if (!ReferenceEquals(model, null))
             {
                 if (model == ChiselModelManager.ActiveModel)
                 {
-                    const float kIconSize     = 16;
-                    const float kOffsetToText = 0.0f;
-                    //const float kOffsetToText = 24.0f;  // this used to be a random '24' in another version of unity?
+                    var content = EditorGUIUtility.TrTempContent(node.name + " (active)");
 
-                    var rect = selectionRect;
-                    rect.xMin += kIconSize + kOffsetToText;
-
-                    var content     = EditorGUIUtility.TrTempContent(node.name + " (active)");
-
-                    // TODO: figure out correct color depending on selection and proSkin
-
-                    GUI.Label(rect, content);
-                    rect.xMin += 0.5f;
-                    GUI.Label(rect, content);
+                    bool selected = GUIView.HasFocus && Selection.Contains(instanceID);
+                    GUI.Label(selectionRect, content, selected ? ChiselSceneGUIStyle.inspectorSelectedLabel : ChiselSceneGUIStyle.inspectorLabel);
                 }
             }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneBottomGUI.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneBottomGUI.cs
@@ -13,50 +13,49 @@ namespace Chisel.Editors
     // TODO: add tooltips
     public static class ChiselSceneBottomGUI
     {
-        internal const float kBottomBarHeight    = 20;
-        const float kFloatFieldWidth    = 60;
-
         static readonly int BottomBarGUIHash = typeof(ChiselSceneBottomGUI).Name.GetHashCode();
 
-        static GUILayoutOption floatWidthLayout;
+        static GUILayoutOption floatWidthLayout = GUILayout.Width(ChiselSceneGUIStyle.kFloatFieldWidth);
 
-        static GUIStyle toolbarStyle;
-        static GUIStyle toggleStyle;
-        static GUIStyle buttonStyle;
-        static bool     prevSkin = false;
 
         // UI Element definitions
-        static GUIContent rebuildButton = new GUIContent("Rebuild");
-        static GUIContent doubleSnapDistanceButton = new GUIContent("+", "Double the snapping distance.\nHotkey: ]");
-        static GUIContent halveSnapDistanceButton = new GUIContent("-", "Halve the snapping distance.\nHotkey: [");
+        static GUIContent rebuildButton             = new GUIContent("Rebuild");
+        static GUIContent doubleSnapDistanceButton  = new GUIContent("+", "Double the snapping distance.\nHotkey: ]");
+        static GUIContent halveSnapDistanceButton   = new GUIContent("-", "Halve the snapping distance.\nHotkey: [");
 
-        static readonly int bottomBarGuiId					= 21001;
+        static readonly int kBottomBarID		    = "ChiselSceneBottomGUI".GetHashCode();
 
 
         public static void Rebuild()
         {
+            var startTime = EditorApplication.timeSinceStartup;
             ChiselNodeHierarchyManager.Rebuild();
+            var csg_endTime = EditorApplication.timeSinceStartup;
+            Debug.Log($"Full CSG rebuild done in {((csg_endTime - startTime) * 1000)} ms. ");
         }
 
-        static void OnBottomBarUI(int windowID)
+        static GUILayoutOption sizeButtonWidth = GUILayout.Width(12);
+
+        static readonly GUI.WindowFunction OnBottomBarUI = OnBottomBarUIFunction;
+        static void OnBottomBarUIFunction(int windowID)
         {
             EditorGUI.BeginChangeCheck();
             GUILayout.BeginHorizontal();
 
             // TODO: assign hotkey to rebuild, and possibly move it elsewhere to avoid it seemingly like a necessary action.
-            if (GUILayout.Button(rebuildButton, buttonStyle)) { 
+            if (GUILayout.Button(rebuildButton, ChiselSceneGUIStyle.buttonStyle)) { 
                 Rebuild();
             }
 
             GUILayout.FlexibleSpace();
 
-            ChiselEditorSettings.ShowGrid = GUILayout.Toggle(ChiselEditorSettings.ShowGrid, "Show Grid", toggleStyle);
+            ChiselEditorSettings.ShowGrid = GUILayout.Toggle(ChiselEditorSettings.ShowGrid, "Show Grid", ChiselSceneGUIStyle.toggleStyle);
 
             ChiselEditorSettings.UniformSnapDistance = EditorGUILayout.FloatField(ChiselEditorSettings.UniformSnapDistance, floatWidthLayout);
-            if (GUILayout.Button(halveSnapDistanceButton, EditorStyles.miniButtonLeft)) {
+            if (GUILayout.Button(halveSnapDistanceButton, EditorStyles.miniButtonLeft, sizeButtonWidth)) {
                 SnappingKeyboard.HalfGridSize();
             }
-            if (GUILayout.Button(doubleSnapDistanceButton, EditorStyles.miniButtonRight)) {
+            if (GUILayout.Button(doubleSnapDistanceButton, EditorStyles.miniButtonRight, sizeButtonWidth)) {
                 SnappingKeyboard.DoubleGridSize();
             }
 
@@ -67,35 +66,15 @@ namespace Chisel.Editors
 
         public static void OnSceneGUI(SceneView sceneView)
         {
-            // TODO: put somewhere else
-            var curSkin = EditorGUIUtility.isProSkin;
-            if (toolbarStyle == null ||
-                prevSkin != curSkin)
-            {
-
-                toolbarStyle = new GUIStyle(EditorStyles.toolbar);
-                toolbarStyle.fixedHeight = kBottomBarHeight;
-
-                toggleStyle = new GUIStyle(EditorStyles.toolbarButton);
-                toggleStyle.fixedHeight = kBottomBarHeight;
-
-                buttonStyle = new GUIStyle(EditorStyles.toolbarButton);
-                buttonStyle.fixedHeight = kBottomBarHeight;
-
-                floatWidthLayout = GUILayout.Width(kFloatFieldWidth);
-
-                prevSkin = curSkin;
-                ChiselEditorSettings.Load();
-            }
-
-
             // Calculate size of bottom bar and draw it
             Rect position = sceneView.position;
-            position.x		= 0;
-            position.y		= position.height - kBottomBarHeight;
-            position.height = kBottomBarHeight; 
+            position.x		= -2;
+            position.y		= position.height - ChiselSceneGUIStyle.kBottomBarHeight + 1;
+            position.width  += 4;
+            position.height = ChiselSceneGUIStyle.kBottomBarHeight;
 
-            GUILayout.Window(bottomBarGuiId, position, OnBottomBarUI, "", toolbarStyle);
+            GUI.Window(kBottomBarID, position, OnBottomBarUI, string.Empty, ChiselSceneGUIStyle.toolbarStyle);
+
             ChiselEditorUtility.ConsumeUnusedMouseEvents(BottomBarGUIHash, position);
         }
     }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneGUIStyle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneGUIStyle.cs
@@ -12,20 +12,30 @@ namespace Chisel.Editors
 {
     public static class ChiselSceneGUIStyle
     {
-        public const float kTopBarHeight        = 22;
-        public const float kBottomBarHeight     = 22;
-        public const float kFloatFieldWidth     = 60;
+        public const float kTopBarHeight = 22;
+        public const float kBottomBarHeight = 22;
+        public const float kFloatFieldWidth = 60;
+
+        const int kIconSize = 16;
+        const int kOffsetToText = 3;
 
         public static GUIStyle toolbarStyle;
         public static GUIStyle windowStyle;
         public static GUIStyle toggleStyle;
         public static GUIStyle buttonStyle;
 
-        static bool prevSkinType = false;
+
+        public static GUIStyle inspectorLabel;
+        public static GUIStyle inspectorSelectedLabel;
+
+        public static bool isInitialized { get; private set; }
+        static bool isProSkin = true;
+        static bool prevIsProSkin = false;
 
         public static GUISkin GetSceneSkin()
         {
-            if (EditorGUIUtility.isProSkin)
+            isProSkin = EditorGUIUtility.isProSkin;
+            if (isProSkin)
             {
                 return EditorGUIUtility.GetBuiltinSkin(EditorSkin.Scene);
             } else
@@ -34,9 +44,20 @@ namespace Chisel.Editors
 
         public static void Update()
         {
-            var curSkin = EditorGUIUtility.isProSkin;
-            if (toolbarStyle != null && prevSkinType == curSkin)
+            isProSkin = EditorGUIUtility.isProSkin;
+            if (toolbarStyle != null && prevIsProSkin == isProSkin)
                 return;
+
+            isInitialized = true;
+            inspectorLabel = new GUIStyle(GUI.skin.label);
+            inspectorLabel.padding = new RectOffset(kIconSize + kOffsetToText, 0, 0, 0);
+
+            inspectorSelectedLabel = new GUIStyle(inspectorLabel);
+            if (!isProSkin)
+            {
+                inspectorSelectedLabel.normal.textColor = Color.white;
+                inspectorSelectedLabel.onNormal.textColor = Color.white;
+            }
 
             windowStyle = new GUIStyle(GUI.skin.window);
 
@@ -53,7 +74,7 @@ namespace Chisel.Editors
             buttonStyle.fixedHeight = kBottomBarHeight - 2;
             buttonStyle.margin = new RectOffset(0, 0, 1, 0);
 
-            prevSkinType = curSkin;
+            prevIsProSkin = isProSkin;
             ChiselEditorSettings.Load(); // <- put somewhere else
         }
     }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneGUIStyle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneGUIStyle.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+using Chisel.Core;
+using Chisel.Components;
+using UnitySceneExtensions;
+
+namespace Chisel.Editors
+{
+    public static class ChiselSceneGUIStyle
+    {
+        public const float kTopBarHeight        = 22;
+        public const float kBottomBarHeight     = 22;
+        public const float kFloatFieldWidth     = 60;
+
+        public static GUIStyle toolbarStyle;
+        public static GUIStyle windowStyle;
+        public static GUIStyle toggleStyle;
+        public static GUIStyle buttonStyle;
+
+        static bool prevSkinType = false;
+
+        public static GUISkin GetSceneSkin()
+        {
+            if (EditorGUIUtility.isProSkin)
+            {
+                return EditorGUIUtility.GetBuiltinSkin(EditorSkin.Scene);
+            } else
+                return EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector);
+        }
+
+        public static void Update()
+        {
+            var curSkin = EditorGUIUtility.isProSkin;
+            if (toolbarStyle != null && prevSkinType == curSkin)
+                return;
+
+            windowStyle = new GUIStyle(GUI.skin.window);
+
+            toolbarStyle = new GUIStyle(GUI.skin.window);
+            toolbarStyle.fixedHeight = kBottomBarHeight;
+            toolbarStyle.padding = new RectOffset(2, 6, 0, 1); 
+            toolbarStyle.contentOffset = Vector2.zero;
+
+            toggleStyle = new GUIStyle(EditorStyles.toolbarButton);
+            toggleStyle.fixedHeight = kBottomBarHeight - 2;
+            toggleStyle.margin = new RectOffset(0, 0, 1, 0);
+
+            buttonStyle = new GUIStyle(EditorStyles.toolbarButton);
+            buttonStyle.fixedHeight = kBottomBarHeight - 2;
+            buttonStyle.margin = new RectOffset(0, 0, 1, 0);
+
+            prevSkinType = curSkin;
+            ChiselEditorSettings.Load(); // <- put somewhere else
+        }
+    }
+}

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneGUIStyle.cs.meta
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselSceneGUIStyle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b8f08d879227e34290fa6abbafc330d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
@@ -152,16 +152,17 @@ namespace Chisel.Editors
             public ChiselNode		node;
             public Transform	transform;
         }
-        static List<SelectedNode>	selectedNode = new List<SelectedNode>();
-        static HashSet<ChiselNode>		foundNodes = new HashSet<ChiselNode>();
+
+        static List<SelectedNode>	selectedNodeList        = new List<SelectedNode>();
+        static HashSet<ChiselNode>	selectedNodeHash        = new HashSet<ChiselNode>();
 
         void UpdateSelection()
         {
             var transforms = Selection.transforms;
-            selectedNode.Clear();
+            selectedNodeList.Clear();
             if (transforms.Length > 0)
             {
-                foundNodes.Clear();
+                selectedNodeHash.Clear();
                 for (int i = 0; i < transforms.Length; i++)
                 {
                     var transform = transforms[i];
@@ -171,12 +172,12 @@ namespace Chisel.Editors
                     if (nodes == null || nodes.Length == 0)
                         continue;
                     foreach (var node in nodes)
-                        foundNodes.Add(node);
+                        selectedNodeHash.Add(node);
                 }
-                foreach (var node in foundNodes)
+                foreach (var node in selectedNodeHash)
                 {
                     var transform = node.transform;
-                    selectedNode.Add(new SelectedNode(node, transform));
+                    selectedNodeList.Add(new SelectedNode(node, transform));
                 }
             }
         }
@@ -184,21 +185,21 @@ namespace Chisel.Editors
         static HashSet<ChiselNode> modifiedNodes = new HashSet<ChiselNode>();
         public void OnSceneGUI(SceneView sceneView)
         {
-            if (selectedNode.Count > 0)
+            if (selectedNodeList.Count > 0)
             {
-                for (int i = 0; i < selectedNode.Count; i++)
+                for (int i = 0; i < selectedNodeList.Count; i++)
                 {
-                    if (!selectedNode[i].transform)
+                    if (!selectedNodeList[i].transform)
                     {
                         UpdateSelection();
                         break;
                     }
                 }
                 modifiedNodes.Clear();
-                for (int i = 0; i < selectedNode.Count; i++)
+                for (int i = 0; i < selectedNodeList.Count; i++)
                 {
-                    var transform	= selectedNode[i].transform;
-                    var node		= selectedNode[i].node;
+                    var transform	= selectedNodeList[i].transform;
+                    var node		= selectedNodeList[i].node;
                     var curLocalToWorldMatrix = transform.localToWorldMatrix;
                     var oldLocalToWorldMatrix = node.hierarchyItem.LocalToWorldMatrix;
                     if (curLocalToWorldMatrix.m00 != oldLocalToWorldMatrix.m00 ||

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Utilities/ChiselGUIUtility.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Utilities/ChiselGUIUtility.cs
@@ -17,8 +17,8 @@ namespace Chisel.Editors
         {
             Rect dragArea = window.position;
             dragArea.x = 0;
-            dragArea.y = kTopBarHeight;
-            dragArea.height -= ChiselSceneBottomGUI.kBottomBarHeight + kTopBarHeight;
+            dragArea.y = ChiselSceneGUIStyle.kTopBarHeight;
+            dragArea.height -= ChiselSceneGUIStyle.kBottomBarHeight + ChiselSceneGUIStyle.kTopBarHeight;
             return dragArea;
         }
     }


### PR DESCRIPTION
Fixed toolbar rendering + hierarchy "active model" highlighting
Should work with 2019.3+ and with both professional/personal skin

Note: in personal skin, when changing the selection, for a split selection the old selection has the wrong color. Unfortunately there's no way to fix this since at that moment Unity still claims the item in the hierarchy is actually selected