### PR TITLE
Clamp side and size fields

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCapsuleEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCapsuleEditor.cs
@@ -22,18 +22,18 @@ namespace Chisel.Editors
         static void DrawOutline(ChiselCapsuleDefinition definition, Vector3[] vertices, LineMode lineMode)
         {
             var sides			= definition.sides;
-            
+
             // TODO: share this logic with GenerateCapsuleVertices
-            
+
             var topHemisphere		= definition.haveRoundedTop;
             var bottomHemisphere	= definition.haveRoundedBottom;
             var topSegments			= topHemisphere    ? definition.topSegments    : 0;
             var bottomSegments		= bottomHemisphere ? definition.bottomSegments : 0;
-            
+
             var extraVertices		= definition.extraVertexCount;
             var bottomVertex		= definition.bottomVertex;
             var topVertex			= definition.topVertex;
-            
+
             var rings				= definition.ringCount;
             var bottomRing			= (bottomHemisphere) ? (rings - bottomSegments) : rings - 1;
             var topRing				= (topHemisphere   ) ? (topSegments - 1) : 0;
@@ -127,10 +127,10 @@ namespace Chisel.Editors
                     var topLoopHasFocus = (topHasFocus && !generator.HaveRoundedTop) || (focusControl == topLoopID);
 
                     var thickness = topLoopHasFocus ? kCapLineThicknessSelected : kCapLineThickness;
-                        
+
                     UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, topLoopHasFocus, true, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(vertices, generator.definition.topVertexOffset, generator.definition.sides, lineMode: LineMode.NoZTest, thickness: thickness);
-                        
+
                     UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, topLoopHasFocus, false, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(vertices, generator.definition.topVertexOffset, generator.definition.sides, lineMode: LineMode.ZTest,   thickness: thickness);
 
@@ -151,7 +151,7 @@ namespace Chisel.Editors
                         GUI.changed = prevGUIChanged;
                     }
                 }
-                
+
                 var bottomId = GUIUtility.GetControlID(s_BottomHash, FocusType.Passive);
                 {
                     var isBottomBackfaced	= ChiselCylinderEditor.IsSufaceBackFaced(bottomPoint, -normal);
@@ -166,7 +166,7 @@ namespace Chisel.Editors
 
                     UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, bottomLoopHasFocus, true, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(vertices, generator.definition.bottomVertexOffset, generator.definition.sides, lineMode: LineMode.NoZTest, thickness: thickness);
-                    
+
                     UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, bottomLoopHasFocus, false, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(vertices, generator.definition.bottomVertexOffset, generator.definition.sides, lineMode: LineMode.ZTest,   thickness: thickness);
 
@@ -199,6 +199,36 @@ namespace Chisel.Editors
                 generator.definition.bottomHeight   = bottomHeight;
                 generator.OnValidate();
                 // TODO: handle sizing down (needs to modify transformation?)
+            }
+        }
+
+        protected override void OnInspector()
+        {
+            base.OnInspector();
+
+            if( !HasValidState() )
+            {
+                foreach( var target in targets )
+                {
+                    var generator = target as ChiselCapsule;
+                    if(!generator)
+                        continue;
+
+                    if( generator.Sides < 3 )
+                        generator.Sides = 3;
+
+                    if( generator.Sides > 64 )
+                        generator.Sides = 64;
+
+                    if( generator.Height < 0.001f )
+                        generator.Height = 0.001f;
+
+                    if( generator.DiameterX == 0 || generator.DiameterZ == 0 )
+                    {
+                        generator.DiameterX = 1;
+                        generator.DiameterZ = 1;
+                    }
+                }
             }
         }
     }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCapsuleEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCapsuleEditor.cs
@@ -217,8 +217,11 @@ namespace Chisel.Editors
                     if( generator.Sides < 3 )
                         generator.Sides = 3;
 
-                    if( generator.Sides > 64 )
-                        generator.Sides = 64;
+                    if( generator.BottomSegments < 2 )
+                        generator.BottomSegments = 2;
+
+                    if( generator.TopSegments < 2 )
+                        generator.TopSegments = 2;
 
                     if( generator.Height < 0.001f )
                         generator.Height = 0.001f;

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCylinderEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCylinderEditor.cs
@@ -364,9 +364,6 @@ namespace Chisel.Editors
                     if( generator.Sides < 3 )
                         generator.Sides = 3;
 
-                    if( generator.Sides > 64 )
-                        generator.Sides = 64;
-
                     if( generator.Height < 0.001f )
                         generator.Height = 0.001f;
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCylinderEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselCylinderEditor.cs
@@ -19,7 +19,7 @@ namespace Chisel.Editors
     {
         [MenuItem("GameObject/Chisel/Create/" + ChiselCylinder.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselCylinder.kNodeTypeName); }
-        
+
         // TODO: put somewhere else
         public static Color GetColorForState(Color baseColor, bool hasFocus, bool isBackfaced, bool isDisabled)
         {
@@ -37,7 +37,7 @@ namespace Chisel.Editors
             var cameraLocalPos			= inverseMatrix.MultiplyPoint(camera.transform.position);
             var cameraLocalForward		= inverseMatrix.MultiplyVector(camera.transform.forward);
             var isCameraOrthographic	= camera.orthographic;
-                
+
             var cosV = isCameraOrthographic ? Vector3.Dot(normal, -cameraLocalForward) :
                                               Vector3.Dot(normal, (cameraLocalPos - point));
 
@@ -108,7 +108,7 @@ namespace Chisel.Editors
 
             Vector3[] vertices;
             Vector3[] dottedVertices;
-            
+
             internal static int s_TopHash				= "TopCylinderHash".GetHashCode();
             internal static int s_BottomHash			= "BottomCylinderHash".GetHashCode();
             internal static int s_TopRotationHash		= "TopRotationCylinderHash".GetHashCode();
@@ -148,7 +148,7 @@ namespace Chisel.Editors
                             {
                                 bottomXVector = UnitySceneExtensions.SceneHandles.Radius2DHandle(topPoint,     normal, bottomXVector, renderDisc: false);
                                 bottomXVector = UnitySceneExtensions.SceneHandles.Radius2DHandle(bottomPoint, -normal, bottomXVector, renderDisc: false);
-                                
+
                                 bottomZVector = bottomXVector;
                             }
                             topXVector = bottomXVector;
@@ -254,27 +254,27 @@ namespace Chisel.Editors
                         }
                     }
                 }
-                
+
                 const float kLineDash					= 2.0f;
                 const float kLineThickness				= 1.0f;
                 const float kCircleThickness			= 1.5f;
                 const float kCapLineThickness			= 2.0f;
                 const float kCapLineThicknessSelected	= 2.5f;
-                 
+
                 const int kMaxOutlineSides	= 32;
                 const int kMinimumSides		= 8;
-                
+
                 var baseColor				= UnityEditor.Handles.yAxisColor;
-                
+
                 BrushMeshFactory.GetConicalFrustumVertices(tempBottom, tempTop, generator.Rotation, sides, ref vertices);
 
                 if (generator.TopHeight < generator.BottomHeight)
                     normal = -normal;
-                    
+
                 var isTopBackfaced	= IsSufaceBackFaced(topPoint, normal);
                 var topHasFocus		= (focusControl == topId);
                 var topThickness	= topHasFocus ? kCapLineThicknessSelected : kCapLineThickness;
-                    
+
                 var isBottomBackfaced	= IsSufaceBackFaced(bottomPoint, -normal);
                 var bottomHasFocus		= (focusControl == bottomId);
                 var bottomThickness		= bottomHasFocus ? kCapLineThicknessSelected : kCapLineThickness;
@@ -285,11 +285,11 @@ namespace Chisel.Editors
 
                 UnityEditor.Handles.color = GetColorForState(baseColor, topHasFocus, isTopBackfaced, isDisabled);
                 ChiselOutlineRenderer.DrawLineLoop(vertices, sides, sides, thickness: topThickness);
-                                        
+
                 UnityEditor.Handles.color = GetColorForState(baseColor, false, false, isDisabled);
                 for (int i = 0; i < sides; i++)
                     ChiselOutlineRenderer.DrawLine(vertices[i], vertices[i + sides], lineMode: LineMode.ZTest, thickness: kLineThickness);
-                    
+
                 UnityEditor.Handles.color = GetColorForState(baseColor, false, true, isDisabled);
                 for (int i = 0; i < sides; i++)
                     ChiselOutlineRenderer.DrawLine(vertices[i], vertices[i + sides], lineMode: LineMode.NoZTest, thickness: kLineThickness);
@@ -308,17 +308,17 @@ namespace Chisel.Editors
 
                     UnityEditor.Handles.color = GetColorForState(baseColor, topHasFocus, false, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(dottedVertices, outlineSides, outlineSides, lineMode: LineMode.ZTest,   thickness: kCircleThickness, dashSize: kLineDash);
-                        
+
                     UnityEditor.Handles.color = GetColorForState(baseColor, topHasFocus, true, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(dottedVertices, outlineSides, outlineSides, lineMode: LineMode.NoZTest, thickness: kCircleThickness, dashSize: kLineDash);
 
                     UnityEditor.Handles.color = GetColorForState(baseColor, bottomHasFocus, false, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(dottedVertices, 0, outlineSides, lineMode: LineMode.ZTest, thickness: kCircleThickness, dashSize: kLineDash);
-                        
+
                     UnityEditor.Handles.color = GetColorForState(baseColor, bottomHasFocus, true, isDisabled);
                     ChiselOutlineRenderer.DrawLineLoop(dottedVertices, 0, outlineSides, lineMode: LineMode.NoZTest, thickness: kCircleThickness, dashSize: kLineDash);
                 }
-                
+
                 EditorGUI.BeginChangeCheck();
                 {
                     UnityEditor.Handles.color = GetColorForState(baseColor, bottomHasFocus, isBottomBackfaced, isDisabled);
@@ -347,6 +347,36 @@ namespace Chisel.Editors
         protected override void OnScene(SceneView sceneView, ChiselCylinder generator)
         {
             cylinderHandle.ShowInstance();
+        }
+
+        protected override void OnInspector()
+        {
+            base.OnInspector();
+
+            if( !HasValidState() )
+            {
+                foreach( var target in targets )
+                {
+                    var generator = target as ChiselCylinder;
+                    if(!generator)
+                        continue;
+
+                    if( generator.Sides < 3 )
+                        generator.Sides = 3;
+
+                    if( generator.Sides > 64 )
+                        generator.Sides = 64;
+
+                    if( generator.Height < 0.001f )
+                        generator.Height = 0.001f;
+
+                    if( generator.DiameterX == 0 || generator.DiameterZ == 0 )
+                    {
+                        generator.DiameterX = 1;
+                        generator.DiameterZ = 1;
+                    }
+                }
+            }
         }
     }
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselHemisphereEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselHemisphereEditor.cs
@@ -37,7 +37,7 @@ namespace Chisel.Editors
             var extraVertices	= ((topCap) ? 1 : 0) + ((bottomCap) ? 1 : 0);
             var bottomVertex	= 0;
             //var topVertex		= (bottomCap) ? 1 : 0;
-            
+
             var rings			= (vertices.Length - extraVertices) / sides;
             var bottomRing		= 0;
 
@@ -61,12 +61,12 @@ namespace Chisel.Editors
             }
             UnityEditor.Handles.color = prevColor;
         }
-        
+
         internal static int s_TopHash		= "TopHemisphereHash".GetHashCode();
 
 
         static Vector3[] vertices = null; // TODO: store this per instance? or just allocate every frame?
-        
+
         protected override void OnScene(SceneView sceneView, ChiselHemisphere generator)
         {
             var baseColor		= UnityEditor.Handles.yAxisColor;
@@ -76,14 +76,14 @@ namespace Chisel.Editors
 
             if (!BrushMeshFactory.GenerateHemisphereVertices(ref generator.definition, ref vertices))
                 return;
-            
-            
+
+
             UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, false, false, isDisabled);
             DrawOutline(generator.definition, vertices, lineMode: LineMode.ZTest);
 
             UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, false, true, isDisabled);
             DrawOutline(generator.definition, vertices, lineMode: LineMode.NoZTest);
-            
+
 
             var topPoint	= normal * generator.DiameterXYZ.y;
             var radius2D	= new Vector2(generator.definition.diameterXYZ.x, generator.definition.diameterXYZ.z) * 0.5f;
@@ -114,6 +114,42 @@ namespace Chisel.Editors
                 diameter.x = radius2D.x * 2.0f;
                 diameter.z = radius2D.x * 2.0f;
                 generator.DiameterXYZ = diameter;
+            }
+        }
+
+        protected override void OnInspector()
+        {
+            base.OnInspector();
+
+            if( !HasValidState() )
+            {
+                foreach( var target in targets )
+                {
+                    var generator = target as ChiselHemisphere;
+                    if(!generator)
+                        continue;
+
+                    if( generator.VerticalSegments < 3 )
+                        generator.VerticalSegments = 3;
+
+                    if( generator.VerticalSegments > 64 )
+                        generator.VerticalSegments = 64;
+
+                    if( generator.HorizontalSegments > 64 )
+                        generator.HorizontalSegments = 64;
+
+                    if( generator.HorizontalSegments < 3 )
+                        generator.HorizontalSegments = 3;
+
+                    if( generator.Height < 0.001f )
+                        generator.Height = 0.001f;
+
+                    if( generator.DiameterX == 0 || generator.DiameterZ == 0 )
+                    {
+                        generator.DiameterX = 1;
+                        generator.DiameterZ = 1;
+                    }
+                }
             }
         }
     }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselHemisphereEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselHemisphereEditor.cs
@@ -132,12 +132,6 @@ namespace Chisel.Editors
                     if( generator.VerticalSegments < 3 )
                         generator.VerticalSegments = 3;
 
-                    if( generator.VerticalSegments > 64 )
-                        generator.VerticalSegments = 64;
-
-                    if( generator.HorizontalSegments > 64 )
-                        generator.HorizontalSegments = 64;
-
                     if( generator.HorizontalSegments < 3 )
                         generator.HorizontalSegments = 3;
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSphereEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSphereEditor.cs
@@ -27,11 +27,11 @@ namespace Chisel.Editors
         static void DrawOutline(ChiselSphereDefinition definition, Vector3[] vertices, LineMode lineMode)
         {
             var sides			= definition.horizontalSegments;
-            
+
             var extraVertices	= 2;
             var bottomVertex	= 1;
             var topVertex		= 0;
-            
+
             var rings			= (vertices.Length - extraVertices) / sides;
 
             var prevColor = UnityEditor.Handles.color;
@@ -59,7 +59,7 @@ namespace Chisel.Editors
 
 
         static Vector3[] vertices = null; // TODO: store this per instance? or just allocate every frame?
-        
+
         protected override void OnScene(SceneView sceneView, ChiselSphere generator)
         {
             var baseColor		= UnityEditor.Handles.yAxisColor;
@@ -128,6 +128,42 @@ namespace Chisel.Editors
                 generator.definition.offsetY    = bottomPoint.y;
                 generator.DiameterXYZ = diameter;
                 // TODO: handle sizing down (needs to modify transformation?)
+            }
+        }
+
+        protected override void OnInspector()
+        {
+            base.OnInspector();
+
+            if( !HasValidState() )
+            {
+                foreach( var target in targets )
+                {
+                    var generator = target as ChiselSphere;
+                    if(!generator)
+                        continue;
+
+                    if( generator.VerticalSegments < 3 )
+                        generator.VerticalSegments = 3;
+
+                    if( generator.VerticalSegments > 64 )
+                        generator.VerticalSegments = 64;
+
+                    if( generator.HorizontalSegments > 64 )
+                        generator.HorizontalSegments = 64;
+
+                    if( generator.HorizontalSegments < 3 )
+                        generator.HorizontalSegments = 3;
+
+                    if( generator.Height < 0.001f )
+                        generator.Height = 0.001f;
+
+                    if( generator.DiameterX == 0 || generator.DiameterZ == 0 )
+                    {
+                        generator.DiameterX = 1;
+                        generator.DiameterZ = 1;
+                    }
+                }
             }
         }
     }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSphereEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSphereEditor.cs
@@ -146,12 +146,6 @@ namespace Chisel.Editors
                     if( generator.VerticalSegments < 3 )
                         generator.VerticalSegments = 3;
 
-                    if( generator.VerticalSegments > 64 )
-                        generator.VerticalSegments = 64;
-
-                    if( generator.HorizontalSegments > 64 )
-                        generator.HorizontalSegments = 64;
-
                     if( generator.HorizontalSegments < 3 )
                         generator.HorizontalSegments = 3;
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
@@ -19,7 +19,7 @@ namespace Chisel.Editors
         [MenuItem("GameObject/Chisel/Create/" + ChiselSpiralStairs.kNodeTypeName, false, 0)]
         static void CreateAsGameObject(MenuCommand menuCommand) { CreateAsGameObjectMenuCommand(menuCommand, ChiselSpiralStairs.kNodeTypeName); }
 
-                        
+
         // TODO: put somewhere else
 
         static readonly int s_RotatedEdge2DHash = "RotatedEdge2D".GetHashCode();
@@ -62,7 +62,7 @@ namespace Chisel.Editors
             if (handleSize == 0.0f)
                 handleSize = UnityEditor.HandleUtility.GetHandleSize(position) * 0.05f;
 
-            
+
             if (evt.GetTypeForControl(id) == EventType.MouseDown &&
                 GUIUtility.hotControl == 0 &&
                 ((UnityEditor.HandleUtility.nearestControl == id && evt.button == 0) ||
@@ -78,8 +78,8 @@ namespace Chisel.Editors
                 return angle;
 
             rotatedAngleOffset += Utilities.GeometryMath.SignedAngle(vector, (newPosition - origin).normalized, handleDir);
-            
-            
+
+
             // TODO: put somewhere else
             if (!Snapping.RotateSnappingActive)
             {
@@ -92,13 +92,13 @@ namespace Chisel.Editors
             return snappedAngle;
         }
 
-        
+
 
 
         Vector3[] innerVertices;
         Vector3[] outerVertices;
 
-        
+
         protected override void OnScene(SceneView sceneView, ChiselSpiralStairs generator)
         {
             var normal					= Vector3.up;
@@ -117,7 +117,7 @@ namespace Chisel.Editors
             var originalTopPoint		= normal * cylinderTop.height;
             var originalLowPoint		= normal * cylinderLow.height;
             var originalMidPoint		= (originalTopPoint + originalLowPoint) * 0.5f;
-                    
+
             var outerDiameter		= originalOuterDiameter;
             var innerDiameter		= originalInnerDiameter;
             var topPoint			= originalTopPoint;
@@ -130,7 +130,7 @@ namespace Chisel.Editors
             {
                 var startRotateEdgeID	= GUIUtility.GetControlID ("SpiralStairsStartAngle".GetHashCode(), FocusType.Keyboard);
                 var endRotateEdgeID		= GUIUtility.GetControlID ("SpiralStairsEndAngle".GetHashCode(), FocusType.Keyboard);
-                        
+
                 // TODO: properly show things as backfaced
                 // TODO: temporarily show inner or outer diameter as disabled when resizing one or the other
                 // TODO: FIXME: why aren't there any arrows?
@@ -139,10 +139,10 @@ namespace Chisel.Editors
                 lowPoint		= UnitySceneExtensions.SceneHandles.DirectionHandle(lowPoint, -normal, snappingStep: originalStepHeight);
                 lowPoint.y		= Mathf.Min(topPoint.y - originalStepHeight, lowPoint.y);
 
-                float minOuterDiameter = innerDiameter + ChiselSpiralStairsDefinition.kMinStairsDepth;						
+                float minOuterDiameter = innerDiameter + ChiselSpiralStairsDefinition.kMinStairsDepth;
                 outerDiameter		= Mathf.Max(minOuterDiameter, UnitySceneExtensions.SceneHandles.RadiusHandle(Vector3.up, topPoint, outerDiameter * 0.5f, renderDisc: false) * 2.0f);
                 outerDiameter		= Mathf.Max(minOuterDiameter, UnitySceneExtensions.SceneHandles.RadiusHandle(Vector3.up, lowPoint, outerDiameter * 0.5f, renderDisc: false) * 2.0f);
-                        
+
                 float maxInnerDiameter = outerDiameter - ChiselSpiralStairsDefinition.kMinStairsDepth;
                 innerDiameter		= Mathf.Min(maxInnerDiameter, UnitySceneExtensions.SceneHandles.RadiusHandle(Vector3.up, midPoint, innerDiameter * 0.5f, renderDisc: false) * 2.0f);
 
@@ -158,7 +158,7 @@ namespace Chisel.Editors
 
                 cylinderTop.diameterZ = cylinderTop.diameterX = cylinderLow.diameterZ = cylinderLow.diameterX = originalOuterDiameter;
                 BrushMeshFactory.GetConicalFrustumVertices(cylinderLow, cylinderTop, 0, generator.OuterSegments, ref outerVertices);
-                
+
                 var originalColor	= UnityEditor.Handles.yAxisColor;
                 var color			= Color.Lerp(originalColor, UnitySceneExtensions.SceneHandles.staticColor, UnitySceneExtensions.SceneHandles.staticBlend);
                 var outlineColor	= Color.black;
@@ -248,6 +248,39 @@ namespace Chisel.Editors
                 }
 
                 generator.OnValidate();
+            }
+        }
+
+        protected override void OnInspector()
+        {
+            base.OnInspector();
+
+            if( !HasValidState() )
+            {
+                foreach( var target in targets )
+                {
+                    var generator = target as ChiselSpiralStairs;
+                    if(!generator)
+                        continue;
+
+                    if( generator.InnerSegments < 3 )
+                        generator.InnerSegments = 3;
+
+                    if( generator.OuterSegments < 3 )
+                        generator.OuterSegments = 3;
+
+                    if( generator.OuterSegments > 64 )
+                        generator.OuterSegments = 64;
+
+                    if( generator.InnerSegments > 64 )
+                        generator.OuterSegments = 64;
+
+                    if( generator.Height < 0.001f )
+                        generator.Height = 0.001f;
+
+                    if( generator.Height == 0 )
+                        generator.Height = 1;
+                }
             }
         }
     }

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselSpiralStairsEditor.cs
@@ -269,12 +269,6 @@ namespace Chisel.Editors
                     if( generator.OuterSegments < 3 )
                         generator.OuterSegments = 3;
 
-                    if( generator.OuterSegments > 64 )
-                        generator.OuterSegments = 64;
-
-                    if( generator.InnerSegments > 64 )
-                        generator.OuterSegments = 64;
-
                     if( generator.Height < 0.001f )
                         generator.Height = 0.001f;
 

--- a/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselTorusEditor.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/ComponentEditors/Generators/ChiselTorusEditor.cs
@@ -32,10 +32,10 @@ namespace Chisel.Editors
 
             var horzSegments	= definition.horizontalSegments;
             var vertSegments	= definition.verticalSegments;
-            
+
             if (definition.totalAngle != 360)
                 horzSegments++;
-            
+
             var prevColor		= UnityEditor.Handles.color;
             prevColor.a *= 0.8f;
             var color			= prevColor;
@@ -73,7 +73,7 @@ namespace Chisel.Editors
             Vector3[] vertices = null;
             if (!BrushMeshFactory.GenerateTorusVertices(generator.definition, ref vertices))
                 return;
-            
+
             UnityEditor.Handles.color = ChiselCylinderEditor.GetColorForState(baseColor, false, false, isDisabled);
             DrawOutline(generator.definition, vertices, lineMode: LineMode.ZTest);
 
@@ -85,7 +85,7 @@ namespace Chisel.Editors
             var innerRadius = generator.definition.innerDiameter * 0.5f;
             var topPoint	= normal * ( generator.definition.tubeHeight * 0.5f);
             var bottomPoint	= normal * (-generator.definition.tubeHeight * 0.5f);
-            
+
             EditorGUI.BeginChangeCheck();
             {
                 UnityEditor.Handles.color = baseColor;
@@ -102,6 +102,22 @@ namespace Chisel.Editors
                 generator.definition.tubeHeight		= (topPoint.y - bottomPoint.y);
                 // TODO: handle sizing down
                 generator.OnValidate();
+            }
+        }
+
+        protected override void OnInspector()
+        {
+            base.OnInspector();
+
+            if( !HasValidState() )
+            {
+                foreach( var target in targets )
+                {
+                    var generator = target as ChiselTorus;
+                    if(!generator)
+                        continue;
+
+                }
             }
         }
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "com.unity.burst": "1.3.0-preview.10",
     "com.unity.entities": "0.9.1-preview.15",
-    "com.unity.ide.visualstudio": "2.0.0",
+    "com.unity.ide.rider": "1.2.1",
+    "com.unity.ide.visualstudio": "2.0.1",
     "com.unity.performance.profile-analyzer": "0.6.0-preview.1",
     "com.unity.ugui": "1.0.0",
     "nuget.mono-cecil": "0.1.6-preview",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.1.0b5
-m_EditorVersionWithRevision: 2020.1.0b5 (f017efceb459)
+m_EditorVersion: 2020.1.0b7
+m_EditorVersionWithRevision: 2020.1.0b7 (6cfebb967dcd)


### PR DESCRIPTION
This prevents a repeatable crash or hang with the unity editor when setting size or side counts on round brushes such as the sphere, cylinder, capsule, etc. by clamping to a minimum value of 3.