### PR TITLE
Fixed the race condition where the rebuild icon wouldn't be loaded.

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselToolsOverlay.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselToolsOverlay.cs
@@ -44,11 +44,6 @@ namespace Chisel.Editors
         static SortedList<string, ChiselEditToolBase> editModes = new SortedList<string, ChiselEditToolBase>();
 
         static GUIContent kRebuildButton;
-        [InitializeOnLoadMethod]
-        internal static void Initialize()
-        {
-            kRebuildButton = ChiselEditorResources.GetIconContent(kRebuildIconName, kRebuildTooltip)[0];
-        }
 
         // TODO: move to dedicated manager
         internal static void Register(ChiselEditToolBase editMode)
@@ -190,6 +185,8 @@ namespace Chisel.Editors
                         position.x = startX + (xPos * buttonStep);
                         var buttonStyle = (index == 7) ? styles.toggleStyleRight :
                                           styles.toggleStyle;
+                        if (kRebuildButton == null)
+                            kRebuildButton = ChiselEditorResources.GetIconContent(kRebuildIconName, kRebuildTooltip)[0];
                         if (GUI.Toggle(position, false, kRebuildButton, buttonStyle))
                         {
                             Rebuild();


### PR DESCRIPTION
`AssetDatabase.LoadAssetAtPath<Texture2D>(path)` has a race condition when used with `[InitializeOnLoadMethod]` - it will return null even though the asset exists around 90% of the time. In a static constructor this issue is resolved (but that crashed with C# reloads) - so I just inlined the loading before it's used for now.