### PR TITLE
Fix Standalone Build Errors

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
@@ -655,6 +655,7 @@ namespace Chisel.Components
             return pickedGeneratedComponent;
         }
 
+#if UNITY_EDITOR
         static readonly Dictionary<Camera, DrawModeFlags>   s_CameraDrawMode    = new Dictionary<Camera, DrawModeFlags>();
 
         static bool s_IgnoreVisibility = false;
@@ -693,5 +694,6 @@ namespace Chisel.Components
         {
             UpdateHelperSurfaceState(DrawModeFlags.Default, ignoreBrushVisibility: true);
         }
+#endif
     }
 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselRenderableObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselRenderableObjects.cs
@@ -171,10 +171,12 @@ namespace Chisel.Components
             {
                 meshRenderer.allowOcclusionWhenDynamic = false;
                 meshRenderer.lightProbeUsage = LightProbeUsage.Off;
-                meshRenderer.scaleInLightmap = 0.0f;
                 meshRenderer.reflectionProbeUsage = ReflectionProbeUsage.Off;
                 meshRenderer.motionVectorGenerationMode = MotionVectorGenerationMode.ForceNoMotion;
                 meshRenderer.shadowCastingMode = ShadowCastingMode.Off;
+#if UNITY_EDITOR
+                meshRenderer.scaleInLightmap = 0.0f;
+#endif
             }
         }
 

--- a/Packages/com.chisel.core/Chisel/Core/Extensions/NativeListExtensions.cs
+++ b/Packages/com.chisel.core/Chisel/Core/Extensions/NativeListExtensions.cs
@@ -24,9 +24,9 @@ namespace Chisel.Core
         public unsafe static ParallelWriterExt<T> AsParallelWriterExt<T>(this NativeList<T> list)
             where T : struct
         {
+            var m_ListData = list.GetUnsafeList();
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
             var m_Safety = NativeListUnsafeUtility.GetAtomicSafetyHandle(ref list);
-            var m_ListData = list.GetUnsafeList();
             return new ParallelWriterExt<T>(m_ListData->Ptr, m_ListData, ref m_Safety);
 #else
             return new ParallelWriterExt<T>(m_ListData->Ptr, m_ListData);
@@ -64,7 +64,7 @@ namespace Chisel.Core
             }
 
 #else
-            internal unsafe ParallelWriter(void* ptr, UnsafeList* listData)
+            internal unsafe ParallelWriterExt(void* ptr, UnsafeList* listData)
             {
                 Ptr = ptr;
                 ListData = listData;


### PR DESCRIPTION
Fix errors caused by missing if UNITY_EDITOR directives, an incorrect constructor name for ParallelWriterExt, and m_ListData not existing in an else portion of code.

![Build Errors 1](https://u.cubeupload.com/BryBread/b65ScreenShot20201116at.png)
![Build Errors 2](https://u.cubeupload.com/BryBread/2dcScreenShot20201116at.png)