### PR TITLE
Csg/cleanup

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselColliderObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselColliderObjects.cs
@@ -108,7 +108,7 @@ namespace Chisel.Components
                 if (!meshCollider)
                     continue;
 
-                // Requires us to set the sharedMesh again, which would force a full slow rebake, 
+                // If the cookingOptions are not the default values it would force a full slow rebake later, 
                 // even if we already did a Bake in a job
                 //if (meshCollider.cookingOptions != colliderSettings.cookingOptions)
                 //    meshCollider.cookingOptions = colliderSettings.cookingOptions;
@@ -125,7 +125,7 @@ namespace Chisel.Components
             }
 
             // TODO: find all the instanceIDs before we start doing CSG, then we can do the Bake's in the same job that sets the meshes
-            //          hopefully that will make it easier for Unity to not fuck up the scheduling
+            //          hopefully that will make it easier for Unity to not screw up the scheduling
             var bakingSettings = new NativeArray<BakeData>(colliders.Length,Allocator.TempJob);
             for (int i = 0; i < colliders.Length; i++)
             {
@@ -150,7 +150,7 @@ namespace Chisel.Components
             {
                 bakingSettings = bakingSettings.AsReadOnly()
             };
-            // WHY ARE THEY RUN SEQUENTIALLY ON THE SAME WORKER THREAD?
+            // WHY ARE ALL OF THESE JOBS SEQUENTIAL ON THE SAME WORKER THREAD?
             var jobHandle = bakeColliderJob.Schedule(colliders.Length, 1);
 
             jobHandle.Complete();

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselColliderObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselColliderObjects.cs
@@ -120,12 +120,8 @@ namespace Chisel.Components
 
                 var sharedMesh = colliders[i].sharedMesh;
                 var expectedEnabled = sharedMesh.vertexCount > 0;
-                if (expectedEnabled)
-                    meshCollider.enabled = !expectedEnabled;
-                meshCollider.enabled = expectedEnabled;
-
-                if (meshCollider.sharedMesh != sharedMesh)
-                    meshCollider.sharedMesh = sharedMesh;
+                if (meshCollider.enabled != expectedEnabled)
+                    meshCollider.enabled = expectedEnabled;
             }
 
             // TODO: find all the instanceIDs before we start doing CSG, then we can do the Bake's in the same job that sets the meshes
@@ -156,7 +152,18 @@ namespace Chisel.Components
             };
             // WHY ARE THEY RUN SEQUENTIALLY ON THE SAME WORKER THREAD?
             var jobHandle = bakeColliderJob.Schedule(colliders.Length, 1);
+
+            jobHandle.Complete();
             bakingSettings.Dispose(jobHandle);
+            // TODO: is there a way to defer forcing the collider to update?
+            for (int i = 0; i < colliders.Length; i++)
+            {
+                var meshCollider = colliders[i].meshCollider;
+                if (!meshCollider)
+                    continue;
+
+                meshCollider.sharedMesh = colliders[i].sharedMesh;
+            }
         }
     }
 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselGeneratedObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/ChiselGeneratedObjects.cs
@@ -459,7 +459,7 @@ namespace Chisel.Components
 
 
             // Now do all kinds of book-keeping code that we might as well do while our jobs are running on other threads
-            Profiler.BeginSample("new ChiselRenderObjectUpdate");
+            Profiler.BeginSample("new_ChiselRenderObjectUpdate");
 
             var usedDebugHelpers = new HashSet<int>();
             for (int i = 0; i < debugHelperMeshes.Length; i++)
@@ -478,7 +478,7 @@ namespace Chisel.Components
             }
             Profiler.EndSample();
 
-            Profiler.BeginSample("new ChiselRenderObjectUpdate");
+            Profiler.BeginSample("new_ChiselRenderObjectUpdate");
             var usedRenderMeshes = new HashSet<int>();
             for (int i = 0; i < renderMeshes.Length; i++)
             {
@@ -496,7 +496,7 @@ namespace Chisel.Components
             }
             Profiler.EndSample();
 
-            Profiler.BeginSample("new ChiselPhysicsObjectUpdate");
+            Profiler.BeginSample("new_ChiselPhysicsObjectUpdate");
             for (int i = 0; i < colliderMeshUpdates.Length; i++)
             {
                 var colliderMeshUpdate  = colliderMeshUpdates[i];

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
@@ -1224,7 +1224,7 @@ namespace Chisel.Core
                 //
                 // Ensure vertices that should be identical on different brushes, ARE actually identical
                 //
-
+                /*
                 #region Merge vertices
                 Profiler.BeginSample("Job_MergeTouchingBrushVertices");
                 try
@@ -1274,7 +1274,7 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
                 #endregion
-
+                */
                 //
                 // Determine all surfaces and intersections
                 //
@@ -1570,6 +1570,7 @@ namespace Chisel.Core
                         if (treeUpdate.updateCount == 0)
                             continue;
                         var dependencies            = CombineDependencies(treeUpdate.allUpdateBrushIndexOrdersJobHandle,
+                                                                          treeUpdate.treeSpaceVerticesCacheJobHandle,
                                                                           treeUpdate.brushesTouchedByBrushCacheJobHandle,
                                                                           treeUpdate.loopVerticesLookupJobHandle);
                         var chiselLookupValues      = ChiselTreeLookup.Value[treeUpdate.treeNodeIndex];
@@ -1578,6 +1579,7 @@ namespace Chisel.Core
                             // Read
                             allUpdateBrushIndexOrders   = treeUpdate.allUpdateBrushIndexOrders.AsDeferredJobArray(),
                             brushesTouchedByBrushCache  = chiselLookupValues.brushesTouchedByBrushCache.AsDeferredJobArray(),
+                            treeSpaceVerticesArray      = chiselLookupValues.treeSpaceVerticesCache.AsDeferredJobArray(),
                             
                             // Read Write
                             loopVerticesLookup          = treeUpdate.loopVerticesLookup,

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
@@ -255,11 +255,7 @@ namespace Chisel.Core
                 //lastJobHandle = disposeJobHandle;
 
 
-                if (meshQueries.IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, meshQueries.Dispose(disposeJobHandle));
-                meshQueries = default;
-
-
-                Profiler.BeginSample("DISPOSE surfaceCountRef");
+                Profiler.BeginSample("DISPOSE_surfaceCountRef");
                 if (surfaceCountRef.IsCreated) surfaceCountRef.Dispose();
                 surfaceCountRef = default;
                 Profiler.EndSample();
@@ -267,17 +263,17 @@ namespace Chisel.Core
                 //if (onlyBlobs)
                 //  return;
 
-                Profiler.BeginSample("DISPOSE ARRAY");
+                Profiler.BeginSample("DISPOSE_ARRAY");
                 if (brushMeshLookup              .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, brushMeshLookup              .Dispose(disposeJobHandle));
                 if (brushIntersectionsWithRange  .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, brushIntersectionsWithRange  .Dispose(disposeJobHandle));
                 if (outputSurfacesRange          .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, outputSurfacesRange          .Dispose(disposeJobHandle));
                 Profiler.EndSample();
 
-                Profiler.BeginSample("DISPOSE LISTARRAY");
+                Profiler.BeginSample("DISPOSE_LISTARRAY");
                 if (loopVerticesLookup           .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, loopVerticesLookup           .Dispose(disposeJobHandle));
                 Profiler.EndSample();
 
-                Profiler.BeginSample("DISPOSE LIST");
+                Profiler.BeginSample("DISPOSE_LIST");
                 if (brushRenderData              .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, brushRenderData              .Dispose(disposeJobHandle));
                 if (subMeshCounts                .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, subMeshCounts                .Dispose(disposeJobHandle));
                 if (subMeshSurfaces              .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, subMeshSurfaces              .Dispose(disposeJobHandle));
@@ -297,7 +293,7 @@ namespace Chisel.Core
                 if (meshDatas                    .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, meshDatas                    .Dispose(disposeJobHandle));
                 Profiler.EndSample();
 
-                Profiler.BeginSample("DISPOSE HASMAP");
+                Profiler.BeginSample("DISPOSE_HASMAP");
                 if (brushesThatNeedIndirectUpdateHashMap.IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, brushesThatNeedIndirectUpdateHashMap.Dispose(disposeJobHandle));
                 if (brushBrushIntersections             .IsCreated) lastJobHandle = CombineDependencies(lastJobHandle, brushBrushIntersections             .Dispose(disposeJobHandle));
                 Profiler.EndSample();

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
@@ -2289,8 +2289,6 @@ namespace Chisel.Core
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
                         ref var treeUpdate = ref s_TreeUpdates[t];
-                        if (treeUpdate.updateCount == 0)
-                            continue;
 
                         // Combine all JobHandles of all jobs to ensure that we wait for ALL of them to finish 
                         // before we dispose of our temporaries.

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/CSGManager.UpdateTreeMeshes.cs
@@ -1150,24 +1150,6 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                Profiler.BeginSample("CSG_OutputSurfacesCapacity");
-                try
-                {
-                    for (int t = 0; t < treeUpdateLength; t++)
-                    {
-                        ref var treeUpdate = ref s_TreeUpdates[t];
-                        if (treeUpdate.updateCount == 0)
-                            continue;
-                        var dependencies            = CombineDependencies(treeUpdate.surfaceCountRefJobHandle,
-                                                                          treeUpdate.outputSurfacesJobHandle); 
-                        var currentJobHandle        = NativeConstruct.ScheduleSetCapacity(ref treeUpdate.outputSurfaces, treeUpdate.surfaceCountRef, dependencies, Allocator.Persistent);
-                        //currentJobHandle.Complete();
-
-                        treeUpdate.outputSurfacesJobHandle  = CombineDependencies(currentJobHandle, treeUpdate.outputSurfacesJobHandle);
-                    }
-                }
-                finally { Profiler.EndSample(); }
-
                 Profiler.BeginSample("Job_InvalidateBrushCache");
                 try
                 {
@@ -1211,10 +1193,10 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                // TODO: should only do this once at creation time, part of brushMeshBlob? store with brush component itself
                 Profiler.BeginSample("Job_CreateTreeSpaceVerticesAndBounds");
                 try
                 {
+                    // TODO: should only do this once at creation time, part of brushMeshBlob? store with brush component itself
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
                         ref var treeUpdate = ref s_TreeUpdates[t];
@@ -1249,10 +1231,10 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                // TODO: only change when brush or any touching brush has been added/removed or changes operation/order
                 Profiler.BeginSample("Job_FindAllBrushIntersectionPairs");
                 try
                 {
+                    // TODO: only change when brush or any touching brush has been added/removed or changes operation/order
                     // TODO: optimize, use hashed grid
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
@@ -1591,10 +1573,10 @@ namespace Chisel.Core
                     }
                 } finally { Profiler.EndSample(); }
 
-                // TODO: should only do this at creation time + when moved / store with brush component itself
                 Profiler.BeginSample("Job_UpdateBrushTreeSpacePlanes");
                 try
                 {
+                    // TODO: should only do this at creation time + when moved / store with brush component itself
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
                         ref var treeUpdate = ref s_TreeUpdates[t];
@@ -1626,10 +1608,10 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                // TODO: only update when brush or any touching brush has been added/removed or changes operation/order
                 Profiler.BeginSample("Job_UpdateBrushCategorizationTables");
                 try
                 {
+                    // TODO: only update when brush or any touching brush has been added/removed or changes operation/order
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
                         ref var treeUpdate = ref s_TreeUpdates[t];
@@ -1690,39 +1672,6 @@ namespace Chisel.Core
                         //treeUpdate.allUpdateBrushIndexOrdersJobHandle  = CombineDependencies(currentJobHandle, treeUpdate.allUpdateBrushIndexOrdersJobHandle);
                         //treeUpdate.brushesTouchedByBrushCacheJobHandle = CombineDependencies(currentJobHandle, treeUpdate.brushesTouchedByBrushCacheJobHandle);
                         treeUpdate.uniqueBrushPairsJobHandle             = CombineDependencies(currentJobHandle, treeUpdate.uniqueBrushPairsJobHandle);
-                    }
-                }
-                finally { Profiler.EndSample(); }
-
-                Profiler.BeginSample("Job_AllocateStreams");
-                try
-                {
-                    for (int t = 0; t < treeUpdateLength; t++)
-                    {
-                        ref var treeUpdate = ref s_TreeUpdates[t];
-                        if (treeUpdate.updateCount == 0)
-                            continue;
-                        { 
-                            var dependencies        = CombineDependencies(treeUpdate.dataStream1JobHandle,
-                                                                          treeUpdate.allUpdateBrushIndexOrdersJobHandle);
-
-                            var currentJobHandle    = NativeStream.ScheduleConstruct(out treeUpdate.dataStream1, treeUpdate.allUpdateBrushIndexOrders, dependencies, Allocator.TempJob);
-                            //currentJobHandle.Complete();
-
-                            //treeUpdate.allUpdateBrushIndexOrdersJobHandle = CombineDependencies(currentJobHandle, treeUpdate.allUpdateBrushIndexOrdersJobHandle);
-                            treeUpdate.dataStream1JobHandle                 = CombineDependencies(currentJobHandle, treeUpdate.dataStream1JobHandle);
-                        }
-                        
-                        { 
-                            var dependencies        = CombineDependencies(treeUpdate.dataStream2JobHandle,
-                                                                          treeUpdate.allUpdateBrushIndexOrdersJobHandle);
-
-                            var currentJobHandle = NativeStream.ScheduleConstruct(out treeUpdate.dataStream2, treeUpdate.allUpdateBrushIndexOrders, dependencies, Allocator.TempJob);
-                            //currentJobHandle.Complete();
-
-                            //treeUpdate.allUpdateBrushIndexOrdersJobHandle = CombineDependencies(currentJobHandle, treeUpdate.allUpdateBrushIndexOrdersJobHandle);
-                            treeUpdate.dataStream2JobHandle                 = CombineDependencies(currentJobHandle, treeUpdate.dataStream2JobHandle);
-                        }
                     }
                 }
                 finally { Profiler.EndSample(); }
@@ -1828,10 +1777,10 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }                
 
-                // TODO: should only do this once at creation time, part of brushMeshBlob? store with brush component itself
                 Profiler.BeginSample("Job_GenerateBasePolygonLoops");
                 try
                 {
+                    // TODO: should only do this once at creation time, part of brushMeshBlob? store with brush component itself
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
                         ref var treeUpdate = ref s_TreeUpdates[t];
@@ -1874,7 +1823,15 @@ namespace Chisel.Core
                         ref var treeUpdate = ref s_TreeUpdates[t];
                         if (treeUpdate.updateCount == 0)
                             continue;
-                        var dependencies            = CombineDependencies(treeUpdate.uniqueBrushPairsJobHandle,
+                        
+                        var dependencies            = CombineDependencies(treeUpdate.surfaceCountRefJobHandle,
+                                                                          treeUpdate.outputSurfacesJobHandle); 
+                        var currentJobHandle        = NativeConstruct.ScheduleSetCapacity(ref treeUpdate.outputSurfaces, treeUpdate.surfaceCountRef, dependencies, Allocator.Persistent);
+                        //currentJobHandle.Complete();
+
+                        treeUpdate.outputSurfacesJobHandle  = CombineDependencies(currentJobHandle, treeUpdate.outputSurfacesJobHandle);
+
+                        dependencies                = CombineDependencies(treeUpdate.uniqueBrushPairsJobHandle,
                                                                           treeUpdate.brushTreeSpacePlaneCacheJobHandle,
                                                                           treeUpdate.treeSpaceVerticesCacheJobHandle,
                                                                           treeUpdate.intersectingBrushesStreamJobHandle,
@@ -1895,7 +1852,7 @@ namespace Chisel.Core
                             outputSurfaceVertices       = treeUpdate.outputSurfaceVertices.AsParallelWriterExt(),
                             outputSurfaces              = treeUpdate.outputSurfaces.AsParallelWriter()
                         };
-                        var currentJobHandle = findAllIntersectionLoopsJob.Schedule(treeUpdate.uniqueBrushPairs, 8, dependencies);
+                        currentJobHandle = findAllIntersectionLoopsJob.Schedule(treeUpdate.uniqueBrushPairs, 8, dependencies);
                         //currentJobHandle.Complete();
                         var disposeJobHandle = treeUpdate.intersectingBrushesStream.Dispose(currentJobHandle);
                         //disposeJobHandle.Complete();
@@ -1944,7 +1901,17 @@ namespace Chisel.Core
                         ref var treeUpdate = ref s_TreeUpdates[t];
                         if (treeUpdate.updateCount == 0)
                             continue;
-                        var dependencies            = CombineDependencies(treeUpdate.allUpdateBrushIndexOrdersJobHandle,
+
+                        var dependencies            = CombineDependencies(treeUpdate.dataStream1JobHandle,
+                                                                          treeUpdate.allUpdateBrushIndexOrdersJobHandle);
+
+                        var currentJobHandle        = NativeStream.ScheduleConstruct(out treeUpdate.dataStream1, treeUpdate.allUpdateBrushIndexOrders, dependencies, Allocator.TempJob);
+                        //currentJobHandle.Complete();
+
+                        //treeUpdate.allUpdateBrushIndexOrdersJobHandle = CombineDependencies(currentJobHandle, treeUpdate.allUpdateBrushIndexOrdersJobHandle);
+                        treeUpdate.dataStream1JobHandle                 = CombineDependencies(currentJobHandle, treeUpdate.dataStream1JobHandle);
+
+                        dependencies                = CombineDependencies(treeUpdate.allUpdateBrushIndexOrdersJobHandle,
                                                                           treeUpdate.outputSurfaceVerticesJobHandle,
                                                                           treeUpdate.outputSurfacesJobHandle,
                                                                           treeUpdate.outputSurfacesRangeJobHandle,
@@ -1970,7 +1937,7 @@ namespace Chisel.Core
                             // Write
                             output                      = treeUpdate.dataStream1.AsWriter()
                         };
-                        var currentJobHandle = findLoopOverlapIntersectionsJob.Schedule(treeUpdate.allUpdateBrushIndexOrders, 1, dependencies);
+                        currentJobHandle = findLoopOverlapIntersectionsJob.Schedule(treeUpdate.allUpdateBrushIndexOrders, 1, dependencies);
                         //currentJobHandle.Complete();
 
                         //treeUpdate.allUpdateBrushIndexOrdersJobHandle = CombineDependencies(currentJobHandle, treeUpdate.allUpdateBrushIndexOrdersJobHandle);
@@ -1984,11 +1951,11 @@ namespace Chisel.Core
                     }
                 } finally { Profiler.EndSample(); }
 
-                // TODO: should only try to merge the vertices beyond the original mesh vertices (the intersection vertices)
-                //       should also try to limit vertices to those that are on the same surfaces (somehow)
                 Profiler.BeginSample("Job_MergeTouchingBrushVerticesIndirect");
                 try
                 {
+                    // TODO: should only try to merge the vertices beyond the original mesh vertices (the intersection vertices)
+                    //       should also try to limit vertices to those that are on the same surfaces (somehow)
                     for (int t = 0; t < treeUpdateLength; t++)
                     {
                         ref var treeUpdate = ref s_TreeUpdates[t];
@@ -2025,7 +1992,17 @@ namespace Chisel.Core
                         ref var treeUpdate = ref s_TreeUpdates[t];
                         if (treeUpdate.updateCount == 0)
                             continue;
-                        var dependencies            = CombineDependencies(treeUpdate.allUpdateBrushIndexOrdersJobHandle,
+
+                        var dependencies            = CombineDependencies(treeUpdate.dataStream2JobHandle,
+                                                                        treeUpdate.allUpdateBrushIndexOrdersJobHandle);
+
+                        var currentJobHandle        = NativeStream.ScheduleConstruct(out treeUpdate.dataStream2, treeUpdate.allUpdateBrushIndexOrders, dependencies, Allocator.TempJob);
+                        //currentJobHandle.Complete();
+
+                        //treeUpdate.allUpdateBrushIndexOrdersJobHandle = CombineDependencies(currentJobHandle, treeUpdate.allUpdateBrushIndexOrdersJobHandle);
+                        treeUpdate.dataStream2JobHandle                 = CombineDependencies(currentJobHandle, treeUpdate.dataStream2JobHandle);
+
+                        dependencies                = CombineDependencies(treeUpdate.allUpdateBrushIndexOrdersJobHandle,
                                                                           treeUpdate.routingTableCacheJobHandle,
                                                                           treeUpdate.brushTreeSpacePlaneCacheJobHandle,
                                                                           treeUpdate.brushesTouchedByBrushCacheJobHandle,
@@ -2049,7 +2026,7 @@ namespace Chisel.Core
                             // Write
                             output                      = treeUpdate.dataStream2.AsWriter(),
                         };
-                        var currentJobHandle = performCSGJob.Schedule(treeUpdate.allUpdateBrushIndexOrders, 1, dependencies);
+                        currentJobHandle = performCSGJob.Schedule(treeUpdate.allUpdateBrushIndexOrders, 1, dependencies);
                         //currentJobHandle.Complete();
                         var disposeJobHandle    = treeUpdate.dataStream1.Dispose(currentJobHandle);
                         //disposeJobHandle.Complete();
@@ -2108,7 +2085,7 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                Profiler.BeginSample("JOB_FindBrushRenderBuffers");
+                Profiler.BeginSample("Job_FindBrushRenderBuffers");
                 try
                 { 
                     for (int t = 0; t < treeUpdateLength; t++)
@@ -2155,7 +2132,7 @@ namespace Chisel.Core
                 // Start the jobs on the worker threads
                 JobHandle.ScheduleBatchedJobs();
 
-                Profiler.BeginSample("JOB_PrepareSubSections");
+                Profiler.BeginSample("Job_PrepareSubSections");
                 try
                 {
                     for (int t = 0; t < treeUpdateLength; t++)
@@ -2187,7 +2164,7 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                Profiler.BeginSample("JOB_SortSurfaces");
+                Profiler.BeginSample("Job_SortSurfaces");
                 try
                 {
                     for (int t = 0; t < treeUpdateLength; t++)
@@ -2284,7 +2261,7 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                Profiler.BeginSample("JOB_AllocateVertexBuffers");
+                Profiler.BeginSample("Job_AllocateVertexBuffers");
                 try
                 {
                     for (int t = 0; t < treeUpdateLength; t++)
@@ -2310,7 +2287,7 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                Profiler.BeginSample("JOB_GenerateMeshDescription");
+                Profiler.BeginSample("Job_GenerateMeshDescription");
                 try
                 {
                     for (int t = 0; t < treeUpdateLength; t++)
@@ -2336,7 +2313,7 @@ namespace Chisel.Core
                 }
                 finally { Profiler.EndSample(); }
 
-                Profiler.BeginSample("JOB_CopyToMeshes");
+                Profiler.BeginSample("Job_CopyToMeshes");
                 try
                 {
                     for (int t = 0; t < treeUpdateLength; t++)

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/Jobs/FindAllBrushIntersectionPairsJob.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/CSG/Jobs/FindAllBrushIntersectionPairsJob.cs
@@ -138,7 +138,7 @@ namespace Chisel.Core
     }
 
     [BurstCompile(CompileSynchronously = true)]
-    struct UpdateUpdateBrushIndexOrdersJob : IJob
+    struct AddIndirectUpdatedBrushesToListAndSortJob : IJob
     {
         // Read
         [NoAlias, ReadOnly] public NativeArray<IndexOrder>.ReadOnly         allTreeBrushIndexOrders;
@@ -193,9 +193,6 @@ namespace Chisel.Core
         // Read (Re-alloc) / Write
         [NativeDisableParallelForRestriction]
         [NoAlias] public NativeListArray<BrushIntersectWith>                brushBrushIntersections;
-
-        // Write
-        [NoAlias, WriteOnly] public NativeList<IndexOrder>.ParallelWriter   allUpdateBrushIndexOrders;
 
         // Per thread scratch memory
         [NativeDisableContainerSafetyRestriction] NativeArray<float4>       transformedPlanes0;

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Thirdparty/Poly2Tri/DTSweep.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Thirdparty/Poly2Tri/DTSweep.cs
@@ -308,7 +308,7 @@ namespace Poly2Tri
         [NoAlias, ReadOnly] public NativeListArray<int>                 children;
         [NoAlias, ReadOnly] public NativeList<Edge>                     inputEdgesCopy;
         [NoAlias, ReadOnly] public NativeListArray<Edge>.NativeList     inputEdges;
-        [NoAlias, ReadOnly] public NativeList<int>                      surfaceIndicesArray;
+        [NoAlias]           public NativeList<int>                      surfaceIndicesArray;
 
         void Clear()
         {

--- a/Packages/com.chisel.core/Chisel/Core/API.public/BrushMesh.Optimize.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/BrushMesh.Optimize.cs
@@ -165,6 +165,18 @@ namespace Chisel.Core
                 vertices[v] = GetVertexFromIntersectingPlanes(v);
             Profiler.EndSample();
 
+            Profiler.BeginSample("RemoveDegenerateTopology");
+            RemoveDegenerateTopology(out _, out _);
+            Profiler.EndSample();
+
+            Profiler.BeginSample("CalculatePlanes");
+            CalculatePlanes();
+            Profiler.EndSample();
+
+            //Profiler.BeginSample("SplitNonPlanarPolygons");
+            //SplitNonPlanarPolygons();
+            //Profiler.EndSample();
+
             Profiler.EndSample();
             return center;
         }

--- a/Packages/com.chisel.core/Chisel/Core/Generators/Brush/ChiselBrushDefinition.cs
+++ b/Packages/com.chisel.core/Chisel/Core/Generators/Brush/ChiselBrushDefinition.cs
@@ -122,7 +122,7 @@ namespace Chisel.Core
                 brushContainer.EnsureSize(1);
                 Profiler.EndSample();
 
-                Profiler.BeginSample("new BrushMesh");
+                Profiler.BeginSample("new_BrushMesh");
                 BrushMesh brushMesh;
                 if (brushContainer.brushMeshes[0] == null)
                 {


### PR DESCRIPTION
* Clean up
* Fixed not freeing memory when tree is unchanged
* Fix for degenerate surfaces being generated
* Fixed issues with Samplers having space in their name
* Fix for updating colliders