### PR TITLE
Update project to Unity 2021.1.10f1

### DIFF
--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselToolsOverlay.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselToolsOverlay.cs
@@ -36,7 +36,7 @@ namespace Chisel.Editors
         }
 
         const int kPrimaryOrder = 98;
-        
+
         const string                    kOverlayTitle   = "Chisel Tools";
         static readonly ChiselOverlay   OverlayWindow   = new ChiselOverlay(kOverlayTitle, DisplayControls, kPrimaryOrder);
 
@@ -71,7 +71,7 @@ namespace Chisel.Editors
         }
 
         static void EditModeButton(Rect position, bool enabled, ChiselEditToolBase editMode, GUIStyle style)
-        { 
+        {
             var editModeType = editMode.GetType();
             using (new EditorGUI.DisabledScope(!enabled))
             {
@@ -154,7 +154,7 @@ namespace Chisel.Editors
                     if (gameObject.TryGetComponent<ChiselNode>(out _))
                         return true;
             }
-            return Selection.GetFiltered<ChiselNode>(SelectionMode.OnlyUserModifiable).Length > 0;
+            return Selection.GetFiltered<ChiselNode>(SelectionMode.Editable).Length > 0;
         }
 
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "com.unity.burst": "1.4.1",
-    "com.unity.entities": "0.16.0-preview.21",
-    "com.unity.ide.visualstudio": "2.0.3",
+    "com.unity.burst": "1.5.4",
+    "com.unity.entities": "0.17.0-preview.42",
+    "com.unity.ide.visualstudio": "2.0.9",
     "com.unity.nuget.newtonsoft-json": "2.0.0",
     "com.unity.performance.profile-analyzer": "1.0.3",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -52,7 +52,7 @@
       "dependencies": {}
     },
     "com.unity.burst": {
-      "version": "1.4.1",
+      "version": "1.5.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -61,54 +61,56 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "0.14.0-preview.16",
+      "version": "0.15.0-preview.21",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.test-framework.performance": "2.3.1-preview",
-        "com.unity.burst": "1.3.7"
+        "com.unity.burst": "1.4.1"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.entities": {
-      "version": "0.16.0-preview.21",
+      "version": "0.17.0-preview.42",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.3.7",
+        "com.unity.burst": "1.4.1",
         "com.unity.properties": "1.5.0-preview",
         "com.unity.serialization": "1.5.0-preview",
-        "com.unity.collections": "0.14.0-preview.16",
+        "com.unity.collections": "0.15.0-preview.21",
         "com.unity.mathematics": "1.2.1",
         "com.unity.modules.assetbundle": "1.0.0",
         "com.unity.test-framework.performance": "2.3.1-preview",
         "com.unity.nuget.mono-cecil": "0.1.6-preview.2",
-        "com.unity.jobs": "0.7.0-preview.17",
+        "com.unity.jobs": "0.8.0-preview.23",
         "com.unity.scriptablebuildpipeline": "1.9.0",
-        "com.unity.platforms": "0.9.0-preview.9"
+        "com.unity.platforms": "0.10.0-preview.10"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
-      "depth": 3,
+      "version": "1.0.6",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.3",
+      "version": "2.0.9",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.test-framework": "1.1.9"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.jobs": {
-      "version": "0.7.0-preview.17",
+      "version": "0.8.0-preview.23",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "0.14.0-preview.16",
+        "com.unity.collections": "0.15.0-preview.21",
         "com.unity.mathematics": "1.2.1"
       },
       "url": "https://packages.unity.com"
@@ -144,64 +146,64 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.platforms": {
-      "version": "0.9.0-preview.9",
+      "version": "0.10.0-preview.10",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.properties": "1.5.0-preview",
-        "com.unity.properties.ui": "1.5.0-preview",
+        "com.unity.properties": "1.6.0-preview",
+        "com.unity.properties.ui": "1.6.2-preview.1",
         "com.unity.scriptablebuildpipeline": "1.6.4-preview",
-        "com.unity.serialization": "1.5.0-preview"
+        "com.unity.serialization": "1.6.2-preview"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.properties": {
-      "version": "1.5.0-preview",
-      "depth": 1,
+      "version": "1.6.0-preview",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.nuget.mono-cecil": "0.1.6-preview.2",
-        "com.unity.test-framework.performance": "2.0.8-preview"
+        "com.unity.test-framework.performance": "2.3.1-preview"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.properties.ui": {
-      "version": "1.5.0-preview",
+      "version": "1.6.2-preview.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.properties": "1.5.0-preview",
-        "com.unity.serialization": "1.5.0-preview",
+        "com.unity.properties": "1.6.0-preview",
+        "com.unity.serialization": "1.6.1-preview",
         "com.unity.modules.uielements": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.scriptablebuildpipeline": {
-      "version": "1.9.0",
+      "version": "1.15.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.serialization": {
-      "version": "1.5.0-preview",
-      "depth": 1,
+      "version": "1.6.2-preview",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.collections": "0.8.0-preview.5",
-        "com.unity.burst": "1.3.0-preview.12",
-        "com.unity.jobs": "0.2.9-preview.15",
-        "com.unity.properties": "1.4.3-preview",
-        "com.unity.test-framework.performance": "2.0.8-preview"
+        "com.unity.collections": "0.12.0-preview.13",
+        "com.unity.burst": "1.3.5",
+        "com.unity.jobs": "0.5.0-preview.14",
+        "com.unity.properties": "1.6.0-preview",
+        "com.unity.test-framework.performance": "2.3.1-preview"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.18",
-      "depth": 2,
+      "version": "1.1.24",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b11
-m_EditorVersionWithRevision: 2020.2.0b11 (c499c2bf2e80)
+m_EditorVersion: 2021.1.10f1
+m_EditorVersionWithRevision: 2021.1.10f1 (b15f561b2cef)


### PR DESCRIPTION
This PR fixes a small compilation error related to `SelectionMode`, and brings Unity and all packages up to current. Due to code changes, I decided to provide this as a PR instead of an unrelated code change when working on the material browser, in case of unexpected behavior.