### PR TITLE
Fixes

### DIFF
--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselAABB.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselAABB.cs
@@ -8,6 +8,7 @@ using Unity.Jobs;
 using Unity.Burst;
 using System.Runtime.CompilerServices;
 
+// Note: Based on Unity.Entities.MinMaxAABB
 namespace Chisel.Core
 {
     [System.Serializable]

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselBlobAssetReference.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselBlobAssetReference.cs
@@ -9,6 +9,7 @@ using Unity.Collections.LowLevel.Unsafe;
 using Unity.Mathematics;
 using UnityEngine;
 
+// Note: Based on Unity.Entities.BlobAssetReference
 namespace Chisel.Core
 {
     readonly unsafe struct ChiselBlobAssetPtr : IEquatable<ChiselBlobAssetPtr>
@@ -512,7 +513,7 @@ namespace Chisel.Core
     /// <see cref="ChiselBlobBuilder"/> instance to set the array elements.</remarks>
     /// <typeparam name="T">The data type of the elements in the array. Must be a struct or other value type.</typeparam>
     /// <seealso cref="ChiselBlobBuilder"/>
-    unsafe public struct ChiselBlobArray<T> where T : struct
+    unsafe public struct ChiselBlobArray<T> where T : unmanaged
     {
         internal int m_OffsetPtr;
         internal int m_Length;

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselBlobBuilder.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselBlobBuilder.cs
@@ -9,6 +9,7 @@ using Unity.Mathematics;
 using UnityEngine.Assertions;
 
 
+// Note: Based on Unity.Entities.BlobBuilder
 namespace Chisel.Core
 {
     /// <summary>
@@ -16,7 +17,7 @@ namespace Chisel.Core
     /// </summary>
     /// <remarks>Use this reference to initialize the data of a newly created <see cref="ChiselBlobArray{T}"/>.</remarks>
     /// <typeparam name="T">The data type of the elements in the array.</typeparam>
-    public unsafe ref struct ChiselBlobBuilderArray<T> where T : struct
+    public unsafe ref struct ChiselBlobBuilderArray<T> where T : unmanaged
     {
         private void* m_data;
         private int m_length;
@@ -171,7 +172,7 @@ namespace Chisel.Core
         /// <param name="data">An array  containing structs of type <typeparamref name="T"/>.</param>
         /// <typeparam name="T">The struct data type.</typeparam>
         /// <returns>A reference to the newly constructed array as a mutable BlobBuilderArray instance.</returns>
-        public ChiselBlobBuilderArray<T> Construct<T>(ref ChiselBlobArray<T> blobArray, params T[] data) where T : struct
+        public ChiselBlobBuilderArray<T> Construct<T>(ref ChiselBlobArray<T> blobArray, params T[] data) where T : unmanaged
         {
             var constructBlobArray = Allocate(ref blobArray, data.Length);
             for (int i = 0; i != data.Length; i++)
@@ -186,7 +187,7 @@ namespace Chisel.Core
         /// <param name="length">The number of elements to allocate.</param>
         /// <typeparam name="T">The struct data type.</typeparam>
         /// <returns>A reference to the newly allocated array as a mutable BlobBuilderArray instance.</returns>
-        public ChiselBlobBuilderArray<T> Allocate<T>(ref ChiselBlobArray<T> ptr, int length) where T : struct
+        public ChiselBlobBuilderArray<T> Allocate<T>(ref ChiselBlobArray<T> ptr, int length) where T : unmanaged
         {
             if (length <= 0)
                 return new ChiselBlobBuilderArray<T>(null, 0);

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselMemory.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselMemory.cs
@@ -4,6 +4,7 @@ using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Mathematics;
 
+// Note: Based on Unity.Entities.Memory
 namespace Chisel.Core.Memory
 {
     [BurstCompatible]

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/CreateBrushTreeSpacePlanesJob.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/CreateBrushTreeSpacePlanesJob.cs
@@ -55,7 +55,8 @@ namespace Chisel.Core
             var brushMeshBlob   = brushMeshLookup[brushNodeOrder];
             if (!brushMeshBlob.IsCreated)
             {
-                Debug.LogError($"BrushMeshBlob invalid for brush with index {brushIndexOrder.compactNodeID}");
+                // The brushMeshID is invalid: a Generator created/didn't update a TreeBrush correctly, or the input values didn't produce a valid mesh (for example; 0 height cube)
+                //Debug.LogError($"BrushMeshBlob invalid for brush with index {brushIndexOrder.compactNodeID}");
                 brushTreeSpacePlanes[brushNodeOrder] = ChiselBlobAssetReference<BrushTreeSpacePlanes>.Null;
                 return;
             }

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/UpdateBrushMeshIDsJob.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/UpdateBrushMeshIDsJob.cs
@@ -50,8 +50,8 @@ namespace Chisel.Core
                         // NOTE: Assignment is intended, this is not supposed to be a comparison
                         (brushMeshHash = compactHierarchy.GetBrushMeshID(brushCompactNodeID)) == 0)
                     {
-                        // The brushMeshID is invalid: a Generator created/didn't update a TreeBrush correctly
-                        Debug.LogError($"Brush with ID ({brushCompactNodeID}) has its brushMeshID set to ({brushMeshHash}), which is invalid.");
+                        // The brushMeshID is invalid: a Generator created/didn't update a TreeBrush correctly, or the input values didn't produce a valid mesh (for example; 0 height cube)
+                        //Debug.LogError($"Brush with ID ({brushCompactNodeID}) has its brushMeshID set to ({brushMeshHash}), which is invalid.");
                         allBrushMeshIDs[nodeOrder] = 0;
                     } else
                     {

--- a/Packages/com.chisel.core/Chisel/Core/API.public/Managed/BrushMesh/BrushMeshManager.Internal.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/Managed/BrushMesh/BrushMeshManager.Internal.cs
@@ -320,7 +320,7 @@ namespace Chisel.Core
         }
 
         
-        public unsafe static BrushMesh ConvertToBrushMesh(ChiselBlobAssetReference<BrushMeshBlob> brushMeshBlobRef, Allocator allocator = Allocator.Persistent)
+        public unsafe static BrushMesh ConvertToBrushMesh(ChiselBlobAssetReference<BrushMeshBlob> brushMeshBlobRef)
         {
             if (!brushMeshBlobRef.IsCreated)
                 return null;

--- a/Packages/com.chisel.core/Chisel/Core/API.public/Managed/Extensions/BlobArrayExtensions.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/Managed/Extensions/BlobArrayExtensions.cs
@@ -7,7 +7,7 @@ namespace Chisel.Core
     internal static class BlobArrayExtensions
     {
         public static bool Contains<T>(ref ChiselBlobArray<T> array, T value)
-            where T : struct
+            where T : unmanaged
         {
             for (int i = 0; i < array.Length; i++)
             {

--- a/Packages/com.chisel.core/Chisel/Core/API.public/Managed/Extensions/ChiselNativeListExtensions.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/Managed/Extensions/ChiselNativeListExtensions.cs
@@ -608,7 +608,7 @@ namespace Chisel.Core
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Contains<T>(ref this ChiselBlobArray<T> array, T value)
-            where T : struct, IEquatable<T>
+            where T : unmanaged, IEquatable<T>
         {
             for (int i = 0; i < array.Length; i++)
             {

--- a/Packages/com.chisel.core/Chisel/Core/GeneratorBase/ChiselCurve2DBlob.cs
+++ b/Packages/com.chisel.core/Chisel/Core/GeneratorBase/ChiselCurve2DBlob.cs
@@ -252,18 +252,18 @@ namespace Chisel.Core
                         polygonVerticesSegments = default;
                         return false;
                     }
+                }
 
-                    for (int i = 0; i < polygonVerticesSegments.Length; i++)
+                for (int i = 0; i < polygonVerticesSegments.Length; i++)
+                {
+                    var range = new Range
                     {
-                        var range = new Range
-                        {
-                            start   = i == 0 ? 0 : polygonVerticesSegments[i - 1],
-                            end     =              polygonVerticesSegments[i    ]
-                        };
+                        start   = i == 0 ? 0 : polygonVerticesSegments[i - 1],
+                        end     =              polygonVerticesSegments[i    ]
+                    };
 
-                        if (CalculateOrientation(polygonVerticesArray, range) < 0)
-                            External.BayazitDecomposerBursted.Reverse(polygonVerticesArray, range);
-                    }
+                    if (CalculateOrientation(polygonVerticesArray, range) < 0)
+                        External.BayazitDecomposerBursted.Reverse(polygonVerticesArray, range);
                 }
                 //Profiler.EndSample();
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ShapeExtrusionHandle.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Handles/ShapeExtrusionHandle.cs
@@ -24,7 +24,7 @@ namespace Chisel.Editors
     public static class ShapeExtrusionHandle
     {
         static Matrix4x4		s_Transformation = Matrix4x4.identity;
-        static ChiselModel			s_ModelBeneathCursor;
+        static ChiselModel		s_ModelBeneathCursor;
         static List<Vector3>	s_Points = new List<Vector3>();
         static Curve2D          s_Curve2D = null;
         static bool             s_ExtrusionMode = false;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselGlobal.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselGlobal.cs
@@ -151,7 +151,7 @@ namespace Chisel.Editors
                 // We set the gameobject to not be active, this will prevent a lot of messages to 
                 // be send by Unity while we're still building the entire sub-hierarchy
                 topGameObject.SetActive(false);
-                var topComponent = ConvertTreeNodeToBrushes(topGameObject, in surfaceDefinition, topNode);
+                var topComponent = ConvertTreeNodeToBrushes(topGameObject, in surfaceDefinition, topNode, chiselNode.PivotOffset);
                 result = topComponent != null;
             }
             finally 
@@ -167,14 +167,15 @@ namespace Chisel.Editors
             return result;
         }
         
-        static ChiselNode ConvertTreeNodeToBrushes(GameObject parent, in ChiselSurfaceDefinition surfaceDefinition, CSGTreeNode node)
+        static ChiselNode ConvertTreeNodeToBrushes(GameObject parent, in ChiselSurfaceDefinition surfaceDefinition, CSGTreeNode node, Vector3 pivotOffset)
         {
             if (node.Type == CSGNodeType.Brush)
             {
                 var brushNode       = (CSGTreeBrush)node;
                 var brushComponent  = ChiselComponentFactory.AddComponent<ChiselBrushComponent>(parent);
-                brushComponent.transform.SetLocal(brushNode.LocalTransformation);
-                brushComponent.Operation                 = brushNode.Operation;
+                //brushComponent.transform.SetLocal(brushNode.LocalTransformation);
+                brushComponent.Operation = brushNode.Operation;
+                brushComponent.PivotOffset = pivotOffset;
 
                 ConvertBrush(brushNode, in surfaceDefinition, out var brushMesh, out var newSurfaceDefinition);
                 brushComponent.surfaceDefinition = newSurfaceDefinition;
@@ -183,7 +184,7 @@ namespace Chisel.Editors
             }
 
             if (node.Count == 1)
-                return ConvertTreeNodeToBrushes(parent, in surfaceDefinition, node[0]);
+                return ConvertTreeNodeToBrushes(parent, in surfaceDefinition, node[0], pivotOffset);
             
             var compositeComponent = ChiselComponentFactory.AddComponent<ChiselComposite>(parent);
             //compositeComponent.transform.SetLocal(node.LocalTransformation);

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
@@ -642,8 +642,8 @@ namespace Chisel.Editors
             int layers = camera.cullingMask;
             var pickposition = GUIClip.GUIClipUnclip(position);
             pickposition = EditorGUIUtility.PointsToPixels(pickposition);
-            pickposition.y = Screen.height - pickposition.y - camera.pixelRect.yMin;
-
+            pickposition.y = camera.pixelRect.height -pickposition.y - camera.pixelRect.yMin;
+            
             var gameObject = PickNodeOrGameObject(camera, pickposition, layers, ref ignore, ref filter, out var model, out var node, out intersection);
             if (!model)
                 return gameObject;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselSurfaceSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselSurfaceSelectionManager.cs
@@ -30,6 +30,38 @@ namespace Chisel.Editors
         {
             selectedSurfacesArray = selectedSurfaces.ToArray();
         }
+
+        // Hack to ensure we don't have objects that have been removed
+        static List<SurfaceReference> s_DestroyedSurfaces = new List<SurfaceReference>();
+        internal void Clean()
+        {
+            s_DestroyedSurfaces.Clear();
+            foreach (var surface in selectedSurfaces)
+                if (surface.node == null)
+                    s_DestroyedSurfaces.Add(surface);
+            foreach (var surface in s_DestroyedSurfaces)
+                selectedSurfaces.Remove(surface);
+
+            s_DestroyedSurfaces.Clear();
+            foreach (var surface in hoverSurfaces)
+                if (surface.node == null)
+                    s_DestroyedSurfaces.Add(surface);
+            foreach (var surface in s_DestroyedSurfaces)
+                hoverSurfaces.Remove(surface);
+
+            s_DestroyedSurfaces.Clear();
+            foreach (var surface in selectedSurfacesArray)
+                if (surface.node == null)
+                    s_DestroyedSurfaces.Add(surface);
+            if (s_DestroyedSurfaces.Count > 0)
+            {
+                var items = selectedSurfacesArray.ToList();
+                foreach (var surface in s_DestroyedSurfaces)
+                    items.Remove(surface);
+                selectedSurfacesArray = items.ToArray();
+            }
+            s_DestroyedSurfaces.Clear();
+        }
     }
     
     public class ChiselSurfaceSelectionManager : SingletonManager<ChiselSurfaceSelection, ChiselSurfaceSelectionManager>
@@ -412,7 +444,12 @@ namespace Chisel.Editors
             return modified;
         }
 
-        
+        // Hack to ensure we don't have objects that have been removed
+        internal static void Clean()
+        {
+            Data.Clean();
+        }
+
         public static bool SetHovering(SelectionType selectionType, HashSet<SurfaceReference> surfaces)
         {
             bool modified;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Visualization/ChiselOutlineRenderer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Visualization/ChiselOutlineRenderer.cs
@@ -335,6 +335,7 @@ namespace Chisel.Editors
         void UpdateSurfaceSelection()
         {	
             surfaceOutlines.Clear();
+            ChiselSurfaceSelectionManager.Clean();
             var selection	= ChiselSurfaceSelectionManager.Selection;
             var hovered		= ChiselSurfaceSelectionManager.Hovered;
             if (selection.Count == 0 &&


### PR DESCRIPTION
Fixed raycasting/selection (due to behavior change in Unity)
Fixed brush placement when converting generator to brushes
Fixed inverted extrusion brushes
Prevent dangling objects in surface selection
No longer showing errors when brush is empty (example; 0 height cube)