### PR TITLE
Placement tools fixes and improvements

### DIFF
--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselBlobAssetReference.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselBlobAssetReference.cs
@@ -516,7 +516,9 @@ namespace Chisel.Core
     unsafe public struct ChiselBlobArray<T> where T : unmanaged
     {
         internal int m_OffsetPtr;
+        #pragma warning disable 0649
         internal int m_Length;
+        #pragma warning restore 0649
 
         /// <summary>
         /// The number of elements in the array.

--- a/Packages/com.chisel.core/Chisel/Core/API.public/Managed/BrushMesh/BrushMesh.Optimize.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/Managed/BrushMesh/BrushMesh.Optimize.cs
@@ -205,6 +205,9 @@ namespace Chisel.Core
                     if (twin < e)
                         continue;
 
+                    if (twin >= halfEdgePolygonIndices.Length)
+                        return true;
+
                     // Find polygon of our twin edge
                     var twinPolygonIndex = halfEdgePolygonIndices[twin]; 
                     ref readonly var twinPolygon = ref polygons[twinPolygonIndex];

--- a/Packages/com.chisel.core/Chisel/Core/GeneratorBase/ChiselPlacementTool.cs
+++ b/Packages/com.chisel.core/Chisel/Core/GeneratorBase/ChiselPlacementTool.cs
@@ -21,6 +21,7 @@ namespace Chisel.Core
     public abstract class ChiselBoundsPlacementTool<PlacementToolType> : ScriptableObject
         where PlacementToolType : IChiselNodeGenerator, new()
     {
+        public virtual bool CreateAsBrush { get; set; } = false;
         public abstract PlacementFlags PlacementFlags { get; }
         public virtual void OnCreate(ref PlacementToolType definition) { }
         public abstract void OnUpdate(ref PlacementToolType definition, Bounds bounds);
@@ -33,6 +34,7 @@ namespace Chisel.Core
     public abstract class ChiselShapePlacementTool<PlacementToolType> : ScriptableObject
         where PlacementToolType : IChiselNodeGenerator, new()
     {
+        public virtual bool CreateAsBrush { get; set; } = false;
         public virtual void OnCreate(ref PlacementToolType definition, Curve2D shape) { }
         public abstract void OnUpdate(ref PlacementToolType definition, float height);
         public abstract void OnPaint(IChiselHandleRenderer renderer, Curve2D shape, float height);

--- a/Packages/com.chisel.core/Chisel/Core/Generators/Box/ChiselBoxPlacementTool.cs
+++ b/Packages/com.chisel.core/Chisel/Core/Generators/Box/ChiselBoxPlacementTool.cs
@@ -6,6 +6,11 @@ namespace Chisel.Core
     [ChiselPlacementTool(name: ChiselBoxDefinition.kNodeTypeName, group: ChiselToolGroups.kBasePrimitives)]
     public sealed class ChiselBoxPlacementTool : ChiselBoundsPlacementTool<ChiselBoxDefinition>
     {
+        [Tooltip("Automatically Convert to Brush on creation")]
+        [SerializeField] bool createAsBrush = false;
+
+        public override bool CreateAsBrush { get { return createAsBrush; } set { createAsBrush = value; } }
+
         [ToggleFlags]
         public PlacementFlags placement = PlacementFlags.None;
         public override PlacementFlags PlacementFlags => placement;
@@ -14,7 +19,7 @@ namespace Chisel.Core
         {
             definition.settings.bounds = new ChiselAABB { Min = bounds.min, Max = bounds.max }; 
         }
-
+         
         public override void OnPaint(IChiselHandleRenderer renderer, Bounds bounds)
         {
             renderer.RenderBox(bounds);

--- a/Packages/com.chisel.core/Chisel/Core/PropertyDrawers/ToggleFlagsAttribute.cs
+++ b/Packages/com.chisel.core/Chisel/Core/PropertyDrawers/ToggleFlagsAttribute.cs
@@ -10,10 +10,17 @@ namespace Chisel.Core
     {
         public ToggleFlagsAttribute(bool showPrefix = true, int includeFlags = ~0, int excludeFlags = 0)
         {
+            if ((includeFlags & (int)PlacementFlags.HeightEqualsXZ) != 0 &&
+                (excludeFlags & (int)PlacementFlags.HeightEqualsXZ) == 0)
+            {
+                includeFlags &= ~(int)PlacementFlags.HeightEqualsHalfXZ;
+                excludeFlags |= (int)PlacementFlags.HeightEqualsHalfXZ;
+            }
+
             this.ShowPrefix = showPrefix;
             this.IncludeFlags = includeFlags;
             this.ExcludeFlags = excludeFlags;
-        }    
+        }
         public readonly bool ShowPrefix;
         public readonly int IncludeFlags;
         public readonly int ExcludeFlags;

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Extensions/ChiselCompositeGUI.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Extensions/ChiselCompositeGUI.cs
@@ -50,22 +50,27 @@ namespace Chisel.Editors
 
         static Styles styles;
 
+        static readonly int kToggleHashCode = $"{nameof(ChiselCompositeGUI)}.Toggle".GetHashCode();
         static bool Toggle(ref Rect toggleRect, bool selected, GUIContent[] content, GUIStyle style)
         {
             var selectedContent = selected ? content[1] : content[0];
 
             EditorGUI.BeginChangeCheck();
-            var result = GUI.Toggle(toggleRect, selected, selectedContent, style);
+            var toggleID = EditorGUIUtility.GetControlID(kToggleLabelHashCode, FocusType.Keyboard, toggleRect);
+            var result = GUI.Toggle(toggleRect, toggleID, selected, selectedContent, style);
             toggleRect.x += toggleRect.width;
 
             return EditorGUI.EndChangeCheck() && result;
         }
+
+        static readonly int kToggleLabelHashCode = $"{nameof(ChiselCompositeGUI)}.ToggleLabel".GetHashCode();
         static bool ToggleLabel(ref Rect toggleRect, bool selected, GUIContent[] content, GUIStyle style)
         {
             var selectedContent = selected ? content[1] : content[0];
 
             EditorGUI.BeginChangeCheck();
-            var result = GUI.Toggle(toggleRect, selected, GUIContent.none, style);
+            var toggleID = EditorGUIUtility.GetControlID(kToggleLabelHashCode, FocusType.Keyboard, toggleRect);
+            var result = GUI.Toggle(toggleRect, toggleID, selected, GUIContent.none, style);
             if (Event.current.type == EventType.Repaint)
                 styles.leftButtonLabel.Draw(toggleRect, selectedContent, false, selected, false, false);
             toggleRect.x += toggleRect.width;
@@ -73,6 +78,7 @@ namespace Chisel.Editors
             return EditorGUI.EndChangeCheck() && result;
         }
 
+        static readonly int kOperationHashCode = $"{nameof(ChiselCompositeGUI)}.Operation".GetHashCode();
         public static void ChooseGeneratorOperation(ref CSGOperationType? operation)
         {
             if (styles == null)
@@ -83,7 +89,8 @@ namespace Chisel.Editors
             rect.yMax -= kBottomPadding;
             EditorGUI.BeginChangeCheck();
             rect.yMin+=2;
-            EditorGUI.PrefixLabel(rect, EditorGUIUtility.TrTextContent("Operation"));
+            var toggleFlagsLabelID = EditorGUIUtility.GetControlID(kOperationHashCode, FocusType.Keyboard, rect);
+            EditorGUI.PrefixLabel(rect, toggleFlagsLabelID, EditorGUIUtility.TrTextContent("Operation"));
             rect.yMin-=2;
             var result = ChiselCompositeGUI.ShowOperationChoicesInternal(rect, operation);
             if (EditorGUI.EndChangeCheck()) { operation = result; }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselDefaultPlacementTools.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselDefaultPlacementTools.cs
@@ -83,7 +83,7 @@ namespace Chisel.Editors
                     break;
                 }
                 
-                case ShapeExtrusionState.Commit:        { Commit(generatedComponent.gameObject); break; }
+                case ShapeExtrusionState.Commit:        { Commit(generatedComponent, PlacementToolDefinition.CreateAsBrush); break; }
                 case ShapeExtrusionState.Cancel:        { Cancel(); break; }
             }
 
@@ -198,7 +198,7 @@ namespace Chisel.Editors
                     break;
                 }
                 
-                case GeneratorModeState.Commit:     { if (generatedComponent) Commit(generatedComponent.gameObject); else Cancel(); break; }
+                case GeneratorModeState.Commit:     { if (generatedComponent) { Commit(generatedComponent, PlacementToolDefinition.CreateAsBrush); } else Cancel(); break; }
                 case GeneratorModeState.Cancel:     { Cancel(); break; }
             }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselPlacementToolInstance.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/ChiselPlacementToolInstance.cs
@@ -51,8 +51,8 @@ namespace Chisel.Editors
                 return placementToolDefinitionInternal;
             }
         }
-        protected CSGOperationType?                                     forceOperation  = null;
-        protected Type                                                  generatorType   = typeof(Generator);
+        protected CSGOperationType?                             forceOperation  = null;
+        protected Type                                          generatorType   = typeof(Generator);
         protected ChiselNodeGeneratorComponent<DefinitionType>  generatedComponent;
 
         static readonly string[] excludeProperties = new[] { "m_Script" };
@@ -121,20 +121,28 @@ namespace Chisel.Editors
             ShapeExtrusionHandle.Reset();
         }
 
-        public void Commit(GameObject newGameObject)
+        public void Commit(ChiselGeneratorComponent generatorComponent, bool createAsBrush)
         {
+            var newGameObject = generatorComponent.gameObject;
             if (!newGameObject)
             {
                 Cancel();
                 return;
             }
+
+            if (createAsBrush)
+            {
+                ConvertToBrushesButton.ConvertToBrushes(generatorComponent);
+                newGameObject.name = ChiselBrushComponent.kNodeTypeName;
+            }
+
             IsGenerating = false;
             UnityEditor.Selection.selectionChanged -= OnDelayedSelectionChanged;
             UnityEditor.Selection.selectionChanged += OnDelayedSelectionChanged;
             UnityEditor.Selection.activeGameObject = newGameObject;
             Undo.IncrementCurrentGroup();
             Reset();
-        }
+        } 
 
         // Unity bug workaround
         void OnDelayedSelectionChanged()
@@ -305,7 +313,7 @@ namespace Chisel.Editors
                             niceName     = niceName,
                             settingsName = settingsName,
                             defaultValue = defaultValue,
-                            fieldInfo        = field
+                            fieldInfo    = field
                         });
                     }
                 }

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselPlacementOptionsOverlay.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Overlays/ChiselPlacementOptionsOverlay.cs
@@ -16,10 +16,10 @@ namespace Chisel.Editors
     [Overlay(typeof(SceneView), ChiselPlacementOptionsOverlay.kOverlayTitle)]
     public class ChiselPlacementOptionsOverlay : IMGUIOverlay, ITransientOverlay
     {
-        public const string kOverlayTitle = "Options";
+        public const string kOverlayTitle = "Placement Options";
 
         // TODO: CLEAN THIS UP
-        public const int kMinWidth = ((248 + 32) - ((32 + 2) * ChiselPlacementToolsSelectionWindow.kToolsWide)) + (ChiselPlacementToolsSelectionWindow.kButtonSize * ChiselPlacementToolsSelectionWindow.kToolsWide);
+        public const int kMinWidth = ((245 + 32) - ((32 + 2) * ChiselPlacementToolsSelectionWindow.kToolsWide)) + (ChiselPlacementToolsSelectionWindow.kButtonSize * ChiselPlacementToolsSelectionWindow.kToolsWide);
         public static readonly GUILayoutOption kMinWidthLayout = GUILayout.MinWidth(kMinWidth);
 
         static bool show = false;
@@ -28,11 +28,19 @@ namespace Chisel.Editors
         public static void Show() { show = true; }
         public static void Hide() { show = false; }
 
+        static ChiselPlacementToolInstance currentInstance;
+
         public override void OnGUI()
         {
             EditorGUILayout.GetControlRect(false, 0, kMinWidthLayout);
             var sceneView = containerWindow as SceneView;
-            ChiselGeneratorManager.GeneratorMode.OnSceneSettingsGUI(sceneView);
+            var generatorMode = ChiselGeneratorManager.GeneratorMode;
+            if (currentInstance != generatorMode)
+            {
+                currentInstance = generatorMode;
+                this.displayName = $"Create {generatorMode.ToolName}";
+            }
+            generatorMode.OnSceneSettingsGUI(sceneView);
         }
     }
 }

--- a/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/HideFoldoutPropertyDrawer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/HideFoldoutPropertyDrawer.cs
@@ -18,6 +18,7 @@ namespace Chisel.Editors
         {
             float totalHeight = 0;
             int startingDepth = iterator.depth;
+            EditorGUIUtility.wideMode = true;
             if (iterator.NextVisible(true))
             {
                 do


### PR DESCRIPTION
- Fixed invalid placement flags
- Fixed error in checking code
- Fixed empty space in generator inspector
- Removed "unused" warning caused by undetectable change through ptr
- Made placement settings work with keyboard
- Placement tool settings are now remembered
- Added "create as brush" toggle to box placement tool