### PR TITLE
Surface fixes

### DIFF
--- a/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
@@ -574,6 +574,7 @@ namespace Chisel.Components
             public Dictionary<UnityEngine.Object, HideFlags>	    hideFlags;
 #if UNITY_EDITOR
             public Dictionary<Renderer, bool>	                    rendererOff;
+            public Dictionary<Renderer, bool>	                    rendererDisabled;
             public Dictionary<UnityEngine.GameObject, bool>	        hierarchyHidden;
             public Dictionary<UnityEngine.GameObject, bool>	        hierarchyDisabled;
 #endif
@@ -602,6 +603,7 @@ namespace Chisel.Components
                 hideFlags           = new Dictionary<UnityEngine.Object, HideFlags>(),
 #if UNITY_EDITOR
                 rendererOff         = new Dictionary<Renderer, bool>(),
+                rendererDisabled    = new Dictionary<Renderer, bool>(),
                 hierarchyHidden     = new Dictionary<UnityEngine.GameObject, bool>(),
                 hierarchyDisabled   = new Dictionary<UnityEngine.GameObject, bool>(),
 #endif
@@ -645,10 +647,11 @@ namespace Chisel.Components
                             continue;
                         state.generatedComponents[debugHelper.container] = model;
 #if UNITY_EDITOR
-                        if (debugHelper.meshRenderer.forceRenderingOff)
+                        if (debugHelper.visible)
                         {
-                            state.rendererOff[debugHelper.meshRenderer] = true;
+                            state.rendererDisabled[debugHelper.meshRenderer] = true;
                             debugHelper.meshRenderer.forceRenderingOff = false;
+                            debugHelper.meshRenderer.enabled = true;
                         }
 #endif
                     }
@@ -704,6 +707,10 @@ namespace Chisel.Components
             foreach (var pair in state.rendererOff)
             {
                 pair.Key.forceRenderingOff = pair.Value;
+            }
+            foreach (var pair in state.rendererDisabled)
+            {
+                pair.Key.enabled = false;
             }
             s_IgnoreVisibility = false;
             EndDrawModeForCamera();

--- a/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.private/ChiselGeneratedComponentManager.cs
@@ -261,15 +261,15 @@ namespace Chisel.Components
                 if (!node || !node.isActiveAndEnabled)
                     continue;
 
-                var brushGenerator = node as ChiselGeneratorComponent;
-                if (brushGenerator)
+                var generatorComponent = node as ChiselGeneratorComponent;
+                if (generatorComponent)
                 {
                     var treeNode = node.TopTreeNode;
                     if (!treeNode.Valid)
                         continue;
-                    var model = brushGenerator.hierarchyItem.Model;
+                    var model = generatorComponent.hierarchyItem.Model;
                     if (model == null)
-                        Debug.LogError($"{brushGenerator.hierarchyItem.Component} model {model} == null", brushGenerator.hierarchyItem.Component);
+                        Debug.LogError($"{generatorComponent.hierarchyItem.Component} model {model} == null", generatorComponent.hierarchyItem.Component);
                     if (model)
                     { 
                         var modelNode           = model.TopTreeNode;
@@ -277,8 +277,10 @@ namespace Chisel.Components
                         var modelCompactNodeID  = CompactHierarchyManager.GetCompactNodeID(modelNode);
                         if (!visibilityStateLookup.TryGetValue(modelCompactNodeID, out VisibilityState prevState))
                             prevState = VisibilityState.Unknown;
-                        var state = UpdateVisibility(sceneVisibilityManager, brushGenerator);
-                        visibilityStateLookup[compactNodeID] = state;
+                        var state = UpdateVisibility(sceneVisibilityManager, generatorComponent);
+
+                        foreach(var childCompactNodeID in CompactHierarchyManager.GetAllChildren(compactNodeID))
+                            visibilityStateLookup[childCompactNodeID] = state;
                         visibilityStateLookup[modelCompactNodeID] = state | prevState;
                     }
                 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/ChiselGeneratorComponent.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Base/ChiselGeneratorComponent.cs
@@ -376,8 +376,8 @@ namespace Chisel.Components
             DestroyChildTreeNodes();
         }
 
-        [HideInInspector, SerializeField] int prevMaterialHash;
-        [HideInInspector, SerializeField] int prevDefinitionHash;
+        [HideInInspector] int prevMaterialHash;
+        [HideInInspector] int prevDefinitionHash;
 
         public void ClearHashes()
         {

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselColliderObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselColliderObjects.cs
@@ -183,7 +183,7 @@ namespace Chisel.Components
 
             bakingSettings.Dispose(allJobHandles);
             //*/
-            /*
+            //*
             // TODO: is there a way to defer forcing the collider to update?
             for (int i = 0; i < colliders.Length; i++)
             {
@@ -192,7 +192,7 @@ namespace Chisel.Components
                     continue;
 
                 meshCollider.sharedMesh = colliders[i].sharedMesh;
-            }*/
+            }//*/
         }
     }
 }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselGeneratedObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselGeneratedObjects.cs
@@ -674,8 +674,7 @@ namespace Chisel.Components
             for (int i = 0; i < debugHelpers.Length; i++)
             {
                 var showState    = (helperStateFlags & kGeneratedDebugShowFlags[i]) != DrawModeFlags.None;
-                if (debugHelpers[i].meshRenderer != null)
-                    debugHelpers[i].meshRenderer.forceRenderingOff = shouldHideMesh || !showState;
+                debugHelpers[i].visible = !shouldHideMesh && showState;
             }
 
             if (ignoreBrushVisibility || !needVisibilityMeshUpdate)

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselRenderableObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselRenderableObjects.cs
@@ -374,11 +374,32 @@ namespace Chisel.Components
                 }
 
                 var gameObjectState = gameObjectStates[objectUpdate.model];
-                var expectedEnabled = vertexBufferContents.triangleBrushIndices[contentsIndex].Length > 0 && !instance.debugHelperRenderer;
+                var expectedEnabled = !instance.debugHelperRenderer && vertexBufferContents.triangleBrushIndices[contentsIndex].Length > 0;
                 if (instance.meshRenderer.enabled != expectedEnabled)
                     instance.meshRenderer.enabled = expectedEnabled;
 
                 instance.UpdateSettings(objectUpdate.model, gameObjectState, objectUpdate.meshIsModified);
+            }
+            Profiler.EndSample();
+        }
+
+
+        public static void UpdateBounds(List<ChiselRenderObjectUpdate> objectUpdates)
+        {
+            Profiler.BeginSample("UpdateBounds");
+            for (int u = 0; u < objectUpdates.Count; u++)
+            {
+                var objectUpdate    = objectUpdates[u];
+                var instance        = objectUpdate.instance;
+                var sharedMesh      = instance.sharedMesh;
+
+                if (sharedMesh.subMeshCount > 0)
+                {
+                    var bounds = sharedMesh.GetSubMesh(0).bounds;
+                    for (int s = 1; s < sharedMesh.subMeshCount; s++)
+                        bounds.Encapsulate(sharedMesh.GetSubMesh(s).bounds);
+                    sharedMesh.bounds = bounds;
+                }
             }
             Profiler.EndSample();
         }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselRenderableObjects.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Components/Containers/Generated/ChiselRenderableObjects.cs
@@ -439,12 +439,18 @@ namespace Chisel.Components
                 int baseVertex          = (int)srcMesh.GetBaseVertex(subMesh);
                 srcMesh.GetTriangles(sSrcTriangles, subMesh, applyBaseVertex: false);
                 sDstTriangles.Clear();
+                var prevBrushID = CompactNodeID.Invalid;
+                var isBrushVisible = true;
                 for (int i = 0; i < sSrcTriangles.Count; i += 3, n++)
                 {
                     if (n < triangleBrushes.Length)
                     { 
-                        var     brushID         = triangleBrushes[n];
-                        bool    isBrushVisible  = ChiselGeneratedComponentManager.IsBrushVisible(brushID);
+                        var brushID = triangleBrushes[n];
+                        if (prevBrushID != brushID)
+                        {
+                            isBrushVisible = ChiselGeneratedComponentManager.IsBrushVisible(brushID);
+                            prevBrushID = brushID;
+                        }
                         if (!isBrushVisible)
                             continue;
                     }

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Query/SurfaceReference.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Query/SurfaceReference.cs
@@ -5,17 +5,17 @@ using Chisel.Core;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using Unity.Collections;
+using System.ComponentModel;
 
 namespace Chisel.Components
 {
     [Serializable]
     public sealed class SurfaceReference : IEquatable<SurfaceReference>, IEqualityComparer<SurfaceReference>
     {
-        public ChiselGeneratorComponent     node;
-        public CSGTreeBrush                 brush;
-
-        public int      descriptionIndex;
-        public int      surfaceIndex;
+        public ChiselGeneratorComponent node;
+        public CSGTreeBrush             brush;
+        public int                      descriptionIndex;
+        public int                      surfaceIndex;
 
         public SurfaceReference(ChiselNode node, int descriptionIndex, CSGTreeBrush brush, int surfaceIndex)
         {
@@ -34,6 +34,37 @@ namespace Chisel.Components
                     return null;
 
                 return node.GetBrushMaterial(descriptionIndex);
+            }
+        }
+
+
+        public Material RenderMaterial
+        {
+            get
+            {
+                if (!node)
+                    return null;
+
+                var brushMaterial = node.GetBrushMaterial(descriptionIndex);
+                if (brushMaterial == null)
+                    return null;
+
+                return brushMaterial.RenderMaterial;
+            }
+            set
+            {
+                if (!node)
+                    return;
+
+                var brushMaterial = node.GetBrushMaterial(descriptionIndex);
+                if (brushMaterial == null)
+                    return;
+
+                if (brushMaterial.RenderMaterial == value)
+                    return;
+
+                brushMaterial.RenderMaterial = value;
+                node.SetDirty();
             }
         }
 
@@ -211,6 +242,11 @@ namespace Chisel.Components
 
 
         #region Equals
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(SurfaceReference left, SurfaceReference right) { return left.Equals(right); }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(SurfaceReference left, SurfaceReference right) { return !left.Equals(right); }
+
         public bool Equals(SurfaceReference other)
         {
             return Equals(this, other);

--- a/Packages/com.chisel.components/Chisel/Components/API.public/Query/SurfaceReference.cs
+++ b/Packages/com.chisel.components/Chisel/Components/API.public/Query/SurfaceReference.cs
@@ -25,10 +25,6 @@ namespace Chisel.Components
             this.surfaceIndex           = surfaceIndex;
         }
 
-        public void SetDirty()
-        {
-            //brushContainerAsset.SetDirty();
-        }
 
         public ChiselBrushMaterial BrushMaterial
         {
@@ -57,6 +53,7 @@ namespace Chisel.Components
                 if (!node)
                     return;
                 node.SetSurfaceUV0(descriptionIndex, value);
+                node.SetDirty();
             }
         }
         public SurfaceDescription SurfaceDescription
@@ -73,6 +70,7 @@ namespace Chisel.Components
                 if (!node)
                     return;
                 node.SetSurfaceDescription(descriptionIndex, value);
+                node.SetDirty();
             }
         }
 

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Managers/CSGManager.UpdateTreeMeshes.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Managed/Managers/CSGManager.UpdateTreeMeshes.cs
@@ -113,6 +113,10 @@ namespace Chisel.Core
                 Profiler.EndSample();
                 #endregion
 
+                //
+                // Schedule chain of jobs that will generate our surface meshes
+                //
+
                 #region Schedule Mesh Update Jobs
                 Profiler.BeginSample("CSG_RunMeshUpdateJobs");
 
@@ -165,6 +169,11 @@ namespace Chisel.Core
                 Profiler.EndSample();
                 #endregion
 
+                //
+                // Dispose temporaries that we don't need anymore
+                //
+
+                #region Dispose temporaries
                 for (int t = 0; t < treeUpdateLength; t++)
                 {
                     ref var treeUpdate = ref s_TreeUpdates[t];
@@ -179,6 +188,7 @@ namespace Chisel.Core
                     
                     treeUpdate.PreMeshUpdateDispose();
                 }
+                #endregion
 
                 JobHandle.ScheduleBatchedJobs();
 
@@ -581,6 +591,7 @@ namespace Chisel.Core
                 Temporaries.brushRenderBufferDisposeList       = new NativeList<ChiselBlobAssetReference<ChiselBrushRenderBuffer>>(chiselLookupValues.brushRenderBufferCache.Length, allocator);
 
                 #endregion
+                
                 Profiler.EndSample();
             }
 

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/JobData/ChiselBrushRenderBuffer.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/JobData/ChiselBrushRenderBuffer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Unity.Mathematics;
 
 namespace Chisel.Core
@@ -35,8 +35,8 @@ namespace Chisel.Core
 
     struct ChiselQuerySurfaces
     {
-        public CompactNodeID                    brushNodeID;
-        public ChiselBlobArray<ChiselQuerySurface>    surfaces;
+        public CompactNodeID                        brushNodeID;
+        public ChiselBlobArray<ChiselQuerySurface>  surfaces;
     }
 
     struct ChiselBrushRenderBuffer

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/FillVertexBuffersJob.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/FillVertexBuffersJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
@@ -440,6 +440,7 @@ namespace Chisel.Core
     public struct ChiselMeshUpdate
     {
         public int contentsIndex;
+        public int colliderIndex;
         public int meshIndex;
         public int objectIndex;
     }
@@ -537,9 +538,9 @@ namespace Chisel.Core
 
             if (colliderMeshUpdates.Capacity < colliderCount)
                 colliderMeshUpdates.Capacity = colliderCount;
-            var colliderIndex = 0;
             if (meshDescriptions.IsCreated)
             {
+                var colliderIndex = 0;
                 for (int i = 0; i < subMeshSections.Length; i++)
                 {
                     var subMeshSection = subMeshSections[i];
@@ -551,10 +552,11 @@ namespace Chisel.Core
                     meshes.Add(meshDatas[meshIndex]);
                     colliderMeshUpdates.Add(new ChiselMeshUpdate
                     {
-                        contentsIndex   = colliderIndex,
+                        contentsIndex   = i,
+                        colliderIndex   = colliderIndex,
                         meshIndex       = meshIndex,
                         objectIndex     = surfaceParameter
-                    }); 
+                    });
                     colliderIndex++;
                     meshIndex++;
                 }

--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -18,10 +18,10 @@ namespace Chisel.Core
         // 'Required' for scheduling with index count
         [NoAlias, ReadOnly] public NativeArray<IndexOrder>                              allUpdateBrushIndexOrders;
         
-        [NoAlias, ReadOnly] public NativeArray<ChiselBlobAssetReference<BasePolygonsBlob>>    basePolygonCache;
-        [NoAlias, ReadOnly] public NativeArray<NodeTransformations>                     transformationCache;
-        [NoAlias, ReadOnly] public NativeStream.Reader                                  input;        
-        [NoAlias, ReadOnly] public NativeArray<MeshQuery>.ReadOnly                      meshQueries;
+        [NoAlias, ReadOnly] public NativeArray<ChiselBlobAssetReference<BasePolygonsBlob>>  basePolygonCache;
+        [NoAlias, ReadOnly] public NativeArray<NodeTransformations>                         transformationCache;
+        [NoAlias, ReadOnly] public NativeStream.Reader                                      input;        
+        [NoAlias, ReadOnly] public NativeArray<MeshQuery>.ReadOnly                          meshQueries;
 
         // Write
         [NativeDisableParallelForRestriction]

--- a/Packages/com.chisel.core/Chisel/Core/API.public/Managed/Managers/CompactHierarchyManager.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/Managed/Managers/CompactHierarchyManager.cs
@@ -572,6 +572,33 @@ namespace Chisel.Core
             return GetCompactNodeID(treeNode.nodeID, out _);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal IEnumerable<CompactNodeID> GetAllChildren(CompactHierarchy hierarchy, CompactNodeID compactNodeID)
+        {
+            yield return compactNodeID;
+            var childCount = hierarchy.ChildCount(compactNodeID);
+            if (childCount == 0)
+                yield break;
+
+            for (int i = 0; i < childCount; i++)
+            {
+                var childCompactNodeID = hierarchy.GetChildCompactNodeIDAt(compactNodeID, i);
+                foreach (var item in GetAllChildren(hierarchy, childCompactNodeID))
+                    yield return item;
+            }
+        }
+
+        // TODO: Optimize
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal IEnumerable<CompactNodeID> GetAllChildren(CompactNodeID compactNodeID)
+        {
+            if (!IsValidCompactNodeID(compactNodeID))
+                yield break;
+
+            foreach (var item in GetAllChildren(GetHierarchy(compactNodeID), compactNodeID))
+                yield return item;
+        }
+
 
         [return: MarshalAs(UnmanagedType.U1)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1917,6 +1944,8 @@ namespace Chisel.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CompactNodeID GetCompactNodeID(CSGTreeNode treeNode) { return instance.GetCompactNodeID(treeNode); }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IEnumerable<CompactNodeID> GetAllChildren(CompactNodeID compactNodeID) { return instance.GetAllChildren(compactNodeID); }
 
         [return: MarshalAs(UnmanagedType.U1)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Packages/com.chisel.core/Chisel/Core/API.public/Unmanaged/BrushMesh/UVMatrix.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.public/Unmanaged/BrushMesh/UVMatrix.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -38,7 +38,7 @@ namespace Chisel.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float4x4 ToFloat4x4() 
         { 
-            return math.transpose(new float4x4 { c0 = U, c1 = V, c2 = new float4(0, 0, 1, 0), c3 = new Vector4(0, 0, 0, 1) }); 
+            return math.transpose(new float4x4 { c0 = U, c1 = V, c2 = new float4(math.cross((Vector3)U, (Vector3)V), 0), c3 = new Vector4(0, 0, 0, 1) }); 
         }
 
         // TODO: add description
@@ -64,54 +64,34 @@ namespace Chisel.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UVMatrix TRS(float2 translation, float rotation, float2 scale)
         {
-            var rotation2d      = quaternion.AxisAngle(new float3(1, 0, 0), math.radians(rotation));
+            var rotation2d      = quaternion.AxisAngle(new float3(0, 0, 1), math.radians(rotation));
             var scale3d         = new float3(scale.x, scale.y, 1.0f);
 
-            // TODO: optimize
-            return (UVMatrix)
-                    (float4x4.TRS(new float3(translation, 0), quaternion.identity, new float3(1)) *
-                     float4x4.TRS(float3.zero, quaternion.identity, scale3d) *
-                     float4x4.TRS(float3.zero, rotation2d, new float3(1)));
+            return (UVMatrix)(float4x4.TRS(new float3(translation, 0), rotation2d, scale3d));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Decompose(out Vector2 translation, out float rotation, out Vector2 scale)
         {
-            var normal  = new float3(0,0,1);
+            translation     = new Vector2(U.w, V.w);
 
-            var u       = (Vector3)U;
-            var v       = (Vector3)V;
+            const double min_translation = 1.0 / 32768.0;
+            translation.x = (float)(math.round(translation.x / min_translation) * min_translation);
+            translation.y = (float)(math.round(translation.y / min_translation) * min_translation);
 
-            if (math.abs(u.x) < kSnapEpsilon) u.x = 0;
-            if (math.abs(u.y) < kSnapEpsilon) u.y = 0;
-            if (math.abs(u.z) < kSnapEpsilon) u.z = 0;
+            var matrix = ToFloat4x4();
 
-            if (math.abs(v.x) < kSnapEpsilon) v.x = 0;
-            if (math.abs(v.y) < kSnapEpsilon) v.y = 0;
-            if (math.abs(v.z) < kSnapEpsilon) v.z = 0;
+            var q = new quaternion(math.transpose((float3x3)matrix));
+            var q_i = math.inverse(q);
+            var q_u = ((UnityEngine.Quaternion)q_i);
 
-            //var inverted = Vector3.Cross(U, V).z < 0.0f;
-
-            var rotationU = -Vector3.SignedAngle(Vector3.right, u, normal);
-            var rotationV = -Vector3.SignedAngle(Vector3.up,    v, normal);
-
-
-            rotation    = math.abs(rotationU) < math.abs(rotationV) ? rotationU : rotationV;
+            rotation = q_u.eulerAngles[2];
 
             const double min_rotate = 1.0 / 10000.0;
             rotation = (float)(Math.Round(rotation / min_rotate) * min_rotate);
-
-            var rotation2d  = Quaternion.AngleAxis(rotation, normal);
-            var invRotate   = Quaternion.Inverse(rotation2d);
-
-            u = (invRotate * U).normalized;
-            v = (invRotate * V).normalized;
             
-            var udir        = new float3(1, 0, 0);
-            var vdir        = new float3(0, 1, 0);
-
-            var uScale      = math.dot(udir, u);
-            var vScale      = math.dot(vdir, v);
+            var uScale = math.length(math.mul(q, matrix.c0.xyz));
+            var vScale = math.length(math.mul(q, matrix.c1.xyz));
             
             scale = new float2(uScale, vScale);
 
@@ -120,18 +100,8 @@ namespace Chisel.Core
 
             scale.x = (float)math.max(math.abs(scale.x), kMinScale) * Math.Sign(scale.x);
             scale.y = (float)math.max(math.abs(scale.y), kMinScale) * Math.Sign(scale.y);
-
-
-            //var rotation2d  = Quaternion.AngleAxis(-rotation, Vector3.forward);
-            translation     = new Vector2(U.w, V.w);
-
-            const double min_translation = 1.0 / 32768.0;
-            translation.x = (float)(math.round(translation.x / min_translation) * min_translation);
-            translation.y = (float)(math.round(translation.y / min_translation) * min_translation);
-
-
-            // TODO: figure out a better way to find if we scale negatively
-            var newUvMatrix = UVMatrix.TRS(translation, rotation, scale);            
+            
+            var newUvMatrix = UVMatrix.TRS(translation, rotation, scale);
             if (math.dot((Vector3)V, (Vector3)newUvMatrix.V) < 0) scale.y = -scale.y;
             if (math.dot((Vector3)U, (Vector3)newUvMatrix.U) < 0) scale.x = -scale.x;
         }

--- a/Packages/com.chisel.core/Chisel/Core/GeneratorBase/IChiselNodeGenerator.cs
+++ b/Packages/com.chisel.core/Chisel/Core/GeneratorBase/IChiselNodeGenerator.cs
@@ -61,10 +61,10 @@ namespace Chisel.Core
 
     public struct GeneratedNode
     {
-        public int                                  parentIndex;    // -1 means root of generated node
-        public CSGOperationType                     operation;
-        public float4x4                             transformation;
-        public ChiselBlobAssetReference<BrushMeshBlob>    brushMesh;      // Note: ignored if type is not Brush
+        public int                                      parentIndex;    // -1 means root of generated node
+        public CSGOperationType                         operation;
+        public float4x4                                 transformation;
+        public ChiselBlobAssetReference<BrushMeshBlob>  brushMesh;      // Note: ignored if type is not Brush
 
 
         public static GeneratedNode GenerateBrush(ChiselBlobAssetReference<BrushMeshBlob> brushMesh, CSGOperationType operation = CSGOperationType.Additive, int parentIndex = -1)

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselClickSelectionManager.cs
@@ -381,115 +381,6 @@ namespace Chisel.Editors
         }
 
 
-        static readonly List<ChiselBrushMaterial> s_TempBrushMaterials = new List<ChiselBrushMaterial>();
-
-        static ChiselBrushMaterial FindBrushMaterialBySurfaceIndex(CSGTreeNode node, CSGTreeBrush brush, int surfaceID)
-        {
-            if (!node.Valid)
-                return null;
-
-            if (surfaceID < 0)
-                return null;
-
-            s_TempBrushMaterials.Clear();
-            if (!GetAllMaterials(node, brush, s_TempBrushMaterials))
-                return null;
-
-            if (surfaceID >= s_TempBrushMaterials.Count)
-                return null;
-
-            var brushMaterial = s_TempBrushMaterials[surfaceID];
-            s_TempBrushMaterials.Clear();
-            return brushMaterial;
-        }
-
-        static bool GetAllMaterials(CSGTreeBrush brush, CSGTreeBrush findBrush, List<ChiselBrushMaterial> brushMaterials)
-        {
-            if (findBrush != brush)
-                return false;
-
-            var brushMeshBlob = BrushMeshManager.GetBrushMeshBlob(brush.BrushMesh.BrushMeshID);
-            if (!brushMeshBlob.IsCreated)
-                return true;
-
-            ref var brushMesh = ref brushMeshBlob.Value;
-            for (int i = 0; i < brushMesh.polygons.Length; i++)
-            {
-                var surface = brushMesh.polygons[i].surface;
-                var brushMaterial = new ChiselBrushMaterial
-                {
-                    LayerUsage = surface.layerDefinition.layerUsage,
-                    RenderMaterial = surface.layerDefinition.layerParameter1 == 0 ? default : ChiselMaterialManager.Instance.GetMaterial(surface.layerDefinition.layerParameter1),
-                    PhysicsMaterial = surface.layerDefinition.layerParameter2 == 0 ? default : ChiselMaterialManager.Instance.GetPhysicMaterial(surface.layerDefinition.layerParameter2)
-                };
-                brushMaterials.Add(brushMaterial);
-            }
-            return true;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool GetAllMaterials(CSGTreeNode node, CSGTreeBrush findBrush, List<ChiselBrushMaterial> brushMaterials)
-        {
-            switch (node.Type)
-            {
-                case CSGNodeType.Branch: return GetAllMaterials((CSGTreeBranch)node, findBrush, brushMaterials);
-                case CSGNodeType.Brush: return GetAllMaterials((CSGTreeBrush)node, findBrush, brushMaterials);
-                default: return false;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool GetAllBrushMaterials(CSGTreeNode node, CSGTreeBrush brush, List<ChiselBrushMaterial> brushMaterials)
-        {
-            if (!node.Valid)
-                return false;
-
-            GetAllMaterials(node, brush, brushMaterials);
-            return brushMaterials.Count > 0;
-        }
-
-        public static bool FindBrushMaterials(Vector2 position, List<ChiselBrushMaterial> outBrushMaterials, List<ChiselNode> nodes, bool selectAllSurfaces)
-        {
-            outBrushMaterials.Clear();
-            nodes.Clear();
-            try
-            {
-                ChiselIntersection intersection;
-                if (!PickFirstGameObject(position, out intersection))
-                    return false;
-
-                var chiselNode = intersection.treeNode;
-                if (!chiselNode)
-                    return false;
-
-                var brush = intersection.brushIntersection.brush;
-
-                if (selectAllSurfaces)
-                {
-                    nodes.Clear();
-                    nodes.Add(chiselNode);
-                    if (!GetAllBrushMaterials(chiselNode.TopTreeNode, brush, outBrushMaterials))
-                        return false;
-                    return true;
-                } else
-                {
-                    var surface = FindBrushMaterialBySurfaceIndex(chiselNode.TopTreeNode, brush, intersection.brushIntersection.surfaceIndex);
-                    if (surface == null)
-                        return false;
-                    nodes.Clear();
-                    nodes.Add(chiselNode);
-                    outBrushMaterials.Add(surface);
-                    return true;
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.LogException(ex);
-                return false;
-            }
-        }
-        
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool FindSurfaceReference(ChiselNode chiselNode, CSGTreeNode node, CSGTreeBrush findBrush, int surfaceID, out SurfaceReference surfaceReference)
         {
@@ -547,7 +438,7 @@ namespace Chisel.Editors
             return null;
         }
         
-        public static bool FindSurfaceReferences(List<SurfaceReference> foundSurfaces, Vector2 position, bool selectAllSurfaces, out ChiselIntersection intersection, out SurfaceReference surfaceReference)
+        public static bool FindSurfaceReferences(Vector2 position, bool selectAllSurfaces, List<SurfaceReference> foundSurfaces, out ChiselIntersection intersection, out SurfaceReference surfaceReference)
         {
             intersection = ChiselIntersection.None;
             surfaceReference = null;
@@ -578,7 +469,12 @@ namespace Chisel.Editors
                 return false;
             }
         }
-        
+
+        public static bool FindSurfaceReferences(Vector2 position, bool selectAllSurfaces, List<SurfaceReference> foundSurfaces)
+        {
+            return FindSurfaceReferences(position, selectAllSurfaces, foundSurfaces, out _, out _);
+        }
+
         static GameObject PickNodeOrGameObject(Camera camera, Vector2 pickposition, int layers, ref GameObject[] ignore, ref GameObject[] filter, out ChiselModel model, out ChiselNode node, out ChiselIntersection intersection)
         {
             TryNextSelection:

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselSurfaceSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselSurfaceSelectionManager.cs
@@ -50,9 +50,12 @@ namespace Chisel.Editors
                 hoverSurfaces.Remove(surface);
 
             s_DestroyedSurfaces.Clear();
-            foreach (var surface in selectedSurfacesArray)
-                if (surface.node == null)
-                    s_DestroyedSurfaces.Add(surface);
+            if (selectedSurfacesArray != null)
+            {
+                foreach (var surface in selectedSurfacesArray)
+                    if (surface.node == null)
+                        s_DestroyedSurfaces.Add(surface);
+            }
             if (s_DestroyedSurfaces.Count > 0)
             {
                 var items = selectedSurfacesArray.ToList();

--- a/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselSurfaceSelectionManager.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/Editor/Scene/Selection/ChiselSurfaceSelectionManager.cs
@@ -102,11 +102,15 @@ namespace Chisel.Editors
         {
             get
             {
-                var selectedSurfaces	= Data.selectedSurfaces;
+                var selectedSurfaces    = Data.selectedSurfaces;
                 var uniqueNodes			= new HashSet<ChiselNode>();
 
                 foreach (var selectedSurface in selectedSurfaces)
+                {
+                    if (selectedSurface.node == null)
+                        continue;
                     uniqueNodes.Add(selectedSurface.node);
+                }
                 return uniqueNodes;
             }
         }
@@ -120,7 +124,7 @@ namespace Chisel.Editors
 
                 foreach (var selectedSurface in selectedSurfaces)
                 {
-                    if (!selectedSurface.node)
+                    if (selectedSurface.node == null)
                         continue;
                     uniqueNodes.Add(selectedSurface.node.gameObject);
                 }
@@ -136,7 +140,11 @@ namespace Chisel.Editors
                 var uniqueBrushMaterials = new HashSet<ChiselBrushMaterial>();
 
                 foreach (var selectedSurface in selectedSurfaces)
+                {
+                    if (selectedSurface.node == null)
+                        continue;
                     uniqueBrushMaterials.Add(selectedSurface.BrushMaterial);
+                }
                 return uniqueBrushMaterials;
             }
         }
@@ -152,6 +160,9 @@ namespace Chisel.Editors
             var selectedSurfaces = Data.selectedSurfaces;
             foreach(var selectedSurface in selectedSurfaces)
             {
+                if (selectedSurface.node == null)
+                    continue;
+
                 if (selectedSurface.BrushMaterial == brushMaterial)
                     return true;
             }
@@ -393,7 +404,7 @@ namespace Chisel.Editors
                     continue;
 
                 var chiselNode = gameObject.GetComponent<ChiselNode>();
-                if (!chiselNode)
+                if (chiselNode == null || !(chiselNode is ChiselGeneratorComponent))
                     continue;
 
                 s_TempSurfaces.Clear();

--- a/Packages/com.chisel.editor/Chisel/Editor/EditorTools/ChiselUVToolCommon.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditorTools/ChiselUVToolCommon.cs
@@ -21,8 +21,8 @@ namespace Chisel.Editors
         public const string kSurfaceDescriptionName = nameof(SurfaceDescription);
         public const string kBrushMaterialName      = nameof(BrushMaterial);
         
-        public SurfaceDescription       SurfaceDescription;
-        public ChiselBrushMaterial      BrushMaterial;
+        public SurfaceDescription               SurfaceDescription;
+        public ChiselBrushMaterial              BrushMaterial;
         [NonSerialized] public SurfaceReference SurfaceReference;
 
         public static ChiselSurfaceContainer Create(SurfaceReference surfaceReference)
@@ -1173,7 +1173,7 @@ namespace Chisel.Editors
                 ChiselIntersection intersection;
                 SurfaceReference surfaceReference;
                 s_TempSurfaces.Clear();
-                if (!ChiselClickSelectionManager.FindSurfaceReferences(s_TempSurfaces, mousePosition, false, out intersection, out surfaceReference))
+                if (!ChiselClickSelectionManager.FindSurfaceReferences(mousePosition, false, s_TempSurfaces, out intersection, out surfaceReference))
                 {
                     modified = (hoverSurfaces != null) || modified;
                     hoverIntersection = null;

--- a/Packages/com.chisel.editor/Chisel/Editor/EditorTools/ChiselUVToolCommon.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditorTools/ChiselUVToolCommon.cs
@@ -1,4 +1,4 @@
-﻿using Chisel.Core;
+using Chisel.Core;
 using Chisel.Components;
 using System;
 using System.Collections.Generic;
@@ -31,7 +31,6 @@ namespace Chisel.Editors
             container.SurfaceReference      = surfaceReference;
             container.SurfaceDescription    = surfaceReference.SurfaceDescription;
             container.BrushMaterial         = surfaceReference.BrushMaterial;
-            //container.BrushSurface        = surfaceReference.BrushSurface;
             container.hideFlags             = HideFlags.DontSave;
             return container;
         }
@@ -39,10 +38,6 @@ namespace Chisel.Editors
         public void Update()
         {
             SurfaceReference.SurfaceDescription = SurfaceDescription;
-            //SurfaceReference.BrushSurface.surfaceDescription.smoothingGroup     = BrushSurface.surfaceDescription.smoothingGroup;
-            //SurfaceReference.BrushSurface.surfaceDescription.surfaceFlags       = BrushSurface.surfaceDescription.surfaceFlags;
-            //SurfaceReference.BrushSurface.surfaceDescription.UV0                = BrushSurface.surfaceDescription.UV0;
-            SurfaceReference.SetDirty();
         }
     }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/EditorTools/ChiselUVToolCommon.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/EditorTools/ChiselUVToolCommon.cs
@@ -35,7 +35,12 @@ namespace Chisel.Editors
             return container;
         }
 
-        public void Update()
+        public void Load()
+        {
+            SurfaceDescription = SurfaceReference.SurfaceDescription;
+        }
+
+        public void Store()
         {
             SurfaceReference.SurfaceDescription = SurfaceDescription;
         }
@@ -111,7 +116,7 @@ namespace Chisel.Editors
         void UpdateSurfaceSelection()
         {
             DestroyOldSurfaces();
-            surfaces        = (from reference in ChiselSurfaceSelectionManager.Selection select ChiselSurfaceContainer.Create(reference)).ToArray();
+            surfaces = (from reference in ChiselSurfaceSelectionManager.Selection select ChiselSurfaceContainer.Create(reference)).ToArray();
             var undoableObjectList = (from surface in surfaces select (UnityEngine.Object)surface.SurfaceReference.node).ToList();                
             //undoableObjectList.AddRange(from surface in surfaces select (UnityEngine.Object)surface.SurfaceReference.brushContainerAsset);
             undoableObjects = undoableObjectList.ToArray();
@@ -140,6 +145,14 @@ namespace Chisel.Editors
             initialized = true;
         }
 
+        void UpdateAllSurfaces()
+        {
+            if (surfaces == null)
+                return;
+            foreach(var surface in surfaces)
+                surface.Load();
+        }
+
         bool initialized = false;
         SerializedObject serializedObject;
         SerializedProperty layerUsageProp;
@@ -156,6 +169,8 @@ namespace Chisel.Editors
         {
             if (!initialized)
                 UpdateSurfaceSelection();
+            else
+                UpdateAllSurfaces();
 
             if (PreviewTextureManager.Update())
                 sceneView.Repaint();
@@ -192,7 +207,7 @@ namespace Chisel.Editors
                 Undo.RegisterCompleteObjectUndo(undoableObjects, undoableObjects.Length > 1 ? "Modified materials" : "Modified material");
                 serializedObject.ApplyModifiedProperties();
                 foreach (var item in surfaces)
-                    item.Update();
+                    item.Store();
             }
         }
 

--- a/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/UVMatrixPropertyDrawer.cs
+++ b/Packages/com.chisel.editor/Chisel/Editor/PropertyDrawers/UVMatrixPropertyDrawer.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using System;
@@ -63,8 +63,8 @@ namespace Chisel.Editors
             var state       = (UVMatrixState)EditorGUIUtility.GetStateObject(typeof(UVMatrixState), translationID);
             if (!state.initialized || state.uvMatrix.U != uvMatrix.U || state.uvMatrix.V != uvMatrix.V)
             {
-                uvMatrix.Decompose(out state.translation, out state.rotation, out state.scale);
                 state.uvMatrix = uvMatrix;
+                uvMatrix.Decompose(out state.translation, out state.rotation, out state.scale);
                 state.initialized = true;
             }
 


### PR DESCRIPTION
* helper surface (visualization of, for example, shadow only surfaces) MeshRenderers are now no longer enabled by default (doesn't show these surfaces when Chisel is not active)
* Fixed hiding regular brushes would hide all brushes of complex generators
* Fixed collider meshes not using correct polygons internally
* Fixed showing surfaces tool window when selecting composite
* Fixed changing surface transformation in surface window
* Fixed surface options tool window not updating when dragging uvs
* Fixed drag & dropping of materials