### PR TITLE
Update ChiselMemory.cs

### DIFF
--- a/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselMemory.cs
+++ b/Packages/com.chisel.core/Chisel/Core/API.private/Unmanaged/ChiselBlobs/ChiselMemory.cs
@@ -59,7 +59,7 @@ namespace Chisel.Core.Memory
                 static void* CustomResize(void* oldPointer, long oldCount, long newCount, Allocator allocator, long size, int align)
                 {
                     AllocatorManager.Block block = default;
-                    block.Range.Allocator = new AllocatorManager.AllocatorHandle { Index = (ushort)allocator };
+                    block.Range.Allocator = new AllocatorManager.AllocatorHandle { Value = (ushort)allocator };
                     block.Range.Items = (int)newCount;
                     block.Range.Pointer = (IntPtr)oldPointer;
                     block.BytesPerItem = (int)size;


### PR DESCRIPTION
Removes CS0117 error in Unity 2021.2.0b7 " 'AllocatorManager.AllocatorHandle' does not contain a definition for 'Index' "
Not sure if it breaks anything in the process *yet*, I have no idea what I'm doing